### PR TITLE
refactor: change mapcar to cl-loop

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -76,7 +76,8 @@
                        ;; TODO (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
-    (mapcar (lambda (choice) (cdr (assoc choice candidates))) chosen)))
+    (cl-loop for choice in chosen
+             collect (cdr (assoc choice candidates)))))
 
 (defun bibtex-actions--get-candidates ()
   "Return all keys from 'bibtex-completion-candidates'."


### PR DESCRIPTION
This changes mapcar to cl-loop in main read function for consistency, 
speed, and because it's a little more clear to me.