### PR TITLE
fix for #39

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -126,18 +126,24 @@ may be indicated with the same icon but a different face."
              collect (cdr (assoc choice candidates)))))
 
 (defun bibtex-actions--get-candidates ()
-  "Return all keys from 'bibtex-completion-candidates'."
+  "Prepare candidates from 'bibtex-completion-candidates'.
+This both propertizes the candidates for display, and grabs the
+key associated with each one."
   (cl-loop
    for candidate in (bibtex-completion-candidates)
    collect
+   (let* ((pdf (if (assoc "=has-pdf=" (cdr candidate)) " has:pdf"))
+          (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
+          (link (if (assoc "doi" (cdr candidate)) "has:link"))
+          (add (s-trim (s-join " " (list pdf note link)))))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward
     ;; when using TAB-completion style multi selection interfaces.
     (propertize
-     (car candidate) 'display (bibtex-completion-format-entry
-     candidate (1- (frame-width)))) ; allow this to be configurable?
-    (cdr (assoc "=key=" candidate)))))
+     (s-append add (car candidate)) 'display (bibtex-completion-format-entry
+     candidate (1- (frame-width))))
+    (cdr (assoc "=key=" candidate))))))
 
 (defun bibtex-actions--affixation (cands)
   "Add affixes to CANDS."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -107,7 +107,6 @@ may be indicated with the same icon but a different face."
 
 
 ;;; Completion functions
-
 (defun bibtex-actions-read ()
   "Read bibtex-completion entries for completion using 'completing-read-multiple'."
   (bibtex-completion-init)
@@ -124,28 +123,21 @@ may be indicated with the same icon but a different face."
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
     (cl-loop for choice in chosen
-             ;; collect citation keys of selected candidate(s)
              collect (cdr (assoc choice candidates)))))
 
 (defun bibtex-actions--get-candidates ()
-  "Prepare candidates from 'bibtex-completion-candidates'.
-This both propertizes the candidates for display, and grabs the
-key associated with each one."
+  "Return all keys from 'bibtex-completion-candidates'."
   (cl-loop
    for candidate in (bibtex-completion-candidates)
    collect
-   (let* ((pdf (if (assoc "=has-pdf=" (cdr candidate)) " has:pdf"))
-          (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
-          (link (if (assoc "doi" (cdr candidate)) "has:link"))
-          (add (s-join " " (list pdf note link))))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward
     ;; when using TAB-completion style multi selection interfaces.
     (propertize
-     (s-append add (car candidate)) 'display (bibtex-completion-format-entry
-     candidate (1- (frame-width))))
-    (cdr (assoc "=key=" candidate))))))
+     (car candidate) 'display (bibtex-completion-format-entry
+     candidate (1- (frame-width)))) ; allow this to be configurable?
+    (cdr (assoc "=key=" candidate)))))
 
 (defun bibtex-actions--affixation (cands)
   "Add affixes to CANDS."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -135,7 +135,7 @@ key associated with each one."
    (let* ((pdf (if (assoc "=has-pdf=" (cdr candidate)) " has:pdf"))
           (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
           (link (if (assoc "doi" (cdr candidate)) "has:link"))
-          (add (s-trim (s-join " " (list pdf note link)))))
+          (add (s-trim-right (s-join " " (list pdf note link)))))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -123,6 +123,7 @@ may be indicated with the same icon but a different face."
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
     (cl-loop for choice in chosen
+             ;; collect citation keys of selected candidate(s)
              collect (cdr (assoc choice candidates)))))
 
 (defun bibtex-actions--get-candidates ()


### PR DESCRIPTION
Something I did with #37 broke crm multi-selection of candidates.

I have narrowed it down to the changes I made to `bibtex-actions--get-candidates`. It's probably something obvious, but I can't see it ATM!

This code now works correctly, but removes the feature I wanted from the offending code: add the pdf/link/note strings to the candidate.

EDIT: an idea: it would be the whitespace I ended up introducing at the end of the candidate strings?

cc @mohkale