### PR TITLE
feature(ui): add suffix 

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -82,7 +82,8 @@ may be indicated with the same icon but a different face."
   (setq bibtex-completion-display-formats
         '((t . "${author:20}   ${title:48}   ${year:4}")))
   (setq bibtex-completion-display-formats-suffix
-        '((t . "${=type=}"))))
+        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:30}"))))
+
 
 ;;; Keymap
 
@@ -135,7 +136,7 @@ key associated with each one."
           (citekey (bibtex-completion-get-value "=key=" candidate))
           (add (s-trim-right (s-join " " (list pdf note link))))
           ; TODO: add separation between target and suffix
-          (suffix  (bibtex-completion-format-entry candidate (1- (frame-width))
+          (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
                         bibtex-completion-display-formats-suffix-internal)))
    (cons
     ;; Here use one string for display, and the other for search.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -124,9 +124,8 @@ may be indicated with the same icon but a different face."
                (lambda (string predicate action)
                  (if (eq action 'metadata)
                      `(metadata
-                       ; TODO add annotation-function?
-                       ,(when bibtex-actions-rich-ui
-                          '(affixation-function . bibtex-actions--affixation))
+                       (affixation-function . bibtex-actions--affixation)
+                       (annotation-function . bibtex-actions--annotation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
     (cl-loop for choice in chosen
@@ -185,12 +184,21 @@ key associated with each one."
                 (cddr (assoc 'note bibtex-actions-symbols))))
          ; grab the custom suffix property
          (suffix
-          (propertize
-           (get-text-property 1 'bibtex-actions-suffix candidate)
-           'face 'bibtex-actions-suffix)))
+          (bibtex-actions--annotation candidate)))
    (list candidate (concat
                     (s-join bibtex-actions-icon-separator
                             (list pdf note))"	") suffix))))
+
+(defun bibtex-actions--annotation (candidate)
+  "Add annotation to CANDIDATE, where affixation is not available."
+  (propertize
+   (get-text-property 1 'bibtex-actions-suffix candidate)
+   'face 'bibtex-actions-suffix))
+
+;;; Formatting functions
+;;; NOTE this section will be removed, or dramatically simplified, if and
+;;; when this PR is merged:
+;;;   https://github.com/tmalsburg/helm-bibtex/pull/367
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -80,9 +80,9 @@ may be indicated with the same icon but a different face."
 
 (when bibtex-actions-rich-ui
   (setq bibtex-completion-display-formats
-        '((t . "${author:20}   ${title:48}   ${year:4}"))))
-  ;(setq bibtex-completion-display-formats-suffix
-  ;      '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
+        '((t . "${author:20}   ${title:48}   ${year:4}")))
+  (setq bibtex-completion-display-formats-suffix
+        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
 
 
 ;;; Keymap
@@ -134,20 +134,10 @@ key associated with each one."
           (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
           (link (if (assoc "doi" (cdr candidate)) "has:link"))
           (citekey (bibtex-completion-get-value "=key=" candidate))
-          (reftype (bibtex-completion-get-value "=type=" candidate))
-          (keywords (or
-                     (bibtex-completion-get-value "tags" candidate)
-                     (bibtex-completion-get-value "keywords" candidate) ""))
           (add (s-trim-right (s-join " " (list pdf note link))))
-          ; TODO: uncomment pending merge of
-          ;    https://github.com/tmalsburg/helm-bibtex/pull/367
-          ; (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
-          ;            bibtex-completion-display-formats-suffix)))
-          (suffix
-           (concat "     "
-            (truncate-string-to-width citekey 25 0 ?\s )
-            (truncate-string-to-width reftype 20 0 ?\s )
-            (truncate-string-to-width keywords 30 0 ?\s ))))
+          ; TODO: add separation between target and suffix
+          (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
+                        bibtex-completion-display-formats-suffix)))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -56,13 +56,24 @@ in previous versions."
   "Face used to highlight suffixes in `bibtex-actions' candidates."
   :group 'bibtex-actions)
 
+(defcustom bibtex-actions-display-templates
+  ; prefix will only work with rich ui, and on Emacs 28
+  ; 'main' is the default entry display string
+  '((prefix . ((t . "${=has-pdf=:1} ${=has-note=:1}  ")))
+    (main   . ((t . "${author:20}   ${title:48}   ${year:4}")))
+    (suffix . ((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
+  "Configures display formatting for 'target', 'prefix' and 'suffix'.
+The latter two are optional, but are used in the 'rich ui'."
+    :group 'bibtex-actions
+    :type  '(alist :key-type symbol :value-type function))
+
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
 This should be a single character."
   :group 'bibtex-actions
   :type 'string)
 
-(defcustom bibtex-actions-icon
+(defcustom bibtex-actions-symbols
   `((pdf .      (,bibtex-completion-pdf-symbol . " "))
     (note .     (,bibtex-completion-notes-symbol . " "))
     (link .     (,bibtex-actions-link-symbol . " ")))
@@ -71,7 +82,7 @@ This leaves room for configurations where the absense of an item
 may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type '(alist :key-type string
-                :value-type (choice (string :tag "Icon"))))
+                :value-type (choice (string :tag "Symbol"))))
 
 (defcustom bibtex-actions-icon-separator " "
   "When using rich UI, the padding between prefix icons."
@@ -80,9 +91,9 @@ may be indicated with the same icon but a different face."
 
 (when bibtex-actions-rich-ui
   (setq bibtex-completion-display-formats
-        '((t . "${author:20}   ${title:48}   ${year:4}")))
-  (setq bibtex-completion-display-formats-suffix
-        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
+        '((t . "${author:20}   ${title:48}   ${year:4}"))))
+  ;(setq bibtex-completion-display-formats-suffix
+  ;      '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
 
 
 ;;; Keymap
@@ -115,6 +126,7 @@ may be indicated with the same icon but a different face."
                (lambda (string predicate action)
                  (if (eq action 'metadata)
                      `(metadata
+                       ; TODO add annotation-function?
                        ,(when bibtex-actions-rich-ui
                           '(affixation-function . bibtex-actions--affixation))
                        (category . bibtex))
@@ -122,6 +134,11 @@ may be indicated with the same icon but a different face."
     (cl-loop for choice in chosen
              ;; collect citation keys of selected candidate(s)
              collect (cdr (assoc choice candidates)))))
+
+(defun bibtex-actions--get-template (template-name)
+  "Use the TEMPLATE-NAME to grab the associated template."
+  (cadadr
+   (assoc template-name bibtex-actions-display-templates)))
 
 (defun bibtex-actions--get-candidates ()
   "Prepare candidates from 'bibtex-completion-candidates'.
@@ -136,15 +153,23 @@ key associated with each one."
           (citekey (bibtex-completion-get-value "=key=" candidate))
           (add (s-trim-right (s-join " " (list pdf note link))))
           ; TODO: add separation between target and suffix
-          (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
-                        bibtex-completion-display-formats-suffix)))
+          (suffix
+           (bibtex-actions--format-entry
+            candidate
+            (1- (frame-width))
+            (bibtex-actions--get-template 'suffix))))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward
     ;; when using TAB-completion style multi selection interfaces.
     (propertize
      (s-append add (car candidate))
-     'display (bibtex-completion-format-entry candidate (1- (frame-width)))
+     ; TODO should width be configurable?
+     'display
+     (bibtex-actions--format-entry
+      candidate
+      (1- (frame-width))
+      (bibtex-actions--get-template 'main))
      ;; Embed the suffix string as a custom property, for use in the affixation
      ;; function.
      'bibtex-actions-suffix suffix)
@@ -156,27 +181,84 @@ key associated with each one."
    for candidate in cands
    collect
    (let ((pdf (if (string-match "has:pdf" candidate)
-                  (car (cdr (assoc 'pdf bibtex-actions-icon)))
-                (cdr (cdr (assoc 'pdf bibtex-actions-icon)))))
-         (link (if (string-match "has:link" candidate)
-                  (car (cdr (assoc 'link bibtex-actions-icon)))
-                (cdr (cdr (assoc 'link bibtex-actions-icon)))))
+                  (cadr (assoc 'pdf bibtex-actions-symbols))
+                (cddr (assoc 'pdf bibtex-actions-symbols))))
+         ;(link (if (string-match "has:link" candidate)
+         ;         (cadr (assoc 'link bibtex-actions-symbols))
+         ;       (cddr (assoc 'link bibtex-actions-symbols))))
          (note
           (if (string-match "has:note" candidate)
-                  (car (cdr (assoc 'note bibtex-actions-icon)))
-                (cdr (cdr (assoc 'note bibtex-actions-icon)))))
+                  (cadr (assoc 'note bibtex-actions-symbols))
+                (cddr (assoc 'note bibtex-actions-symbols))))
          ; grab the custom suffix property
-         (suffix (propertize (get-text-property 1 'bibtex-actions-suffix candidate)
-                             'face 'bibtex-actions-suffix)))
+         (suffix
+          (propertize
+           (get-text-property 1 'bibtex-actions-suffix candidate)
+           'face 'bibtex-actions-suffix)))
    (list candidate (concat
                     (s-join bibtex-actions-icon-separator
                             (list pdf note))"	") suffix))))
 
-;(defun bibtex-actions--make-suffix (entry)
-;  "Create the formatted ENTRY suffix string for the 'rich-ui'."
-;    ;;TODO unclear if needed, or how to do it if it is.
-;    ;; may need change in bibtex-completion-format-entry
-;    )
+(defun bibtex-actions--process-display-formats (formats)
+  "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."
+  ; adapted from bibtex-completion
+  (cl-loop
+   for format in formats
+   collect
+   (let* ((format-string (cdr format))
+          (fields-width 0)
+          (string-width
+           (string-width
+            (s-format format-string
+                      (lambda (field)
+                        (setq fields-width
+                              (+ fields-width
+                                 (string-to-number
+                                  (or (cadr (split-string field ":"))
+                                      ""))))
+                        "")))))
+     (-cons* (car format) format-string (+ fields-width string-width)))))
+
+(defun bibtex-actions--format-entry (entry width template)
+  "Formats a BibTeX ENTRY for display in results list.
+WIDTH is the width of the results list, and the display format is governed by
+TEMPLATE."
+  ; adapted from bibtex-completion
+  (let* ((processed-template
+          (bibtex-actions--process-display-formats template))
+         (format
+          (or
+           ; if there's a template specific to the type, use that
+           (assoc-string
+            (bibtex-completion-get-value "=type=" entry) template 'case-fold)
+           ; if not, use the generic template
+           (assoc t processed-template)))
+         (format-string (cadr format)))
+    (s-format
+     format-string
+     (lambda (field)
+       (let* ((field (split-string field ":"))
+              (field-name (car field))
+              (field-width (cadr field))
+              (field-value (bibtex-completion-get-value field-name entry)))
+         (when (and (string= field-name "author")
+                    (not field-value))
+           (setq field-value (bibtex-completion-get-value "editor" entry)))
+         (when (and (string= field-name "year")
+                    (not field-value))
+           (setq field-value (car (split-string (bibtex-completion-get-value "date" entry "") "-"))))
+         (setq field-value (bibtex-completion-clean-string (or field-value " ")))
+         (when (member field-name '("author" "editor"))
+           (setq field-value (bibtex-completion-shorten-authors field-value)))
+         (if (not field-width)
+             field-value
+           (setq field-width (string-to-number field-width))
+           (truncate-string-to-width
+            field-value
+            (if (> field-width 0)
+                field-width
+              (- width (cddr format)))
+            0 ?\s)))))))
 
 ;;; Command wrappers for bibtex-completion functions
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -56,9 +56,6 @@ in previous versions."
   "Face used to highlight suffixes in `bibtex-actions' candidates."
   :group 'bibtex-actions)
 
-(defvar bibtex-actions-suffix-format
-  "(${citekey}) ${reftype}:${tags}")
-
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
 This should be a single character."
@@ -83,7 +80,9 @@ may be indicated with the same icon but a different face."
 
 (when bibtex-actions-rich-ui
   (setq bibtex-completion-display-formats
-        '((t . "${author:20}   ${title:48}   ${year:4}"))))
+        '((t . "${author:20}   ${title:48}   ${year:4}")))
+  (setq bibtex-completion-display-formats-suffix
+        '((t . "${=type=}"))))
 
 ;;; Keymap
 
@@ -133,12 +132,11 @@ key associated with each one."
    (let* ((pdf (if (assoc "=has-pdf=" (cdr candidate)) " has:pdf"))
           (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
           (link (if (assoc "doi" (cdr candidate)) "has:link"))
-          (add (s-trim-right (s-join " " (list pdf note link))))
-          (tags (or (bibtex-completion-get-value "tags" candidate)
-                    (bibtex-completion-get-value "keywords" candidate) ""))
-          (reftype (bibtex-completion-get-value "=type=" candidate))
           (citekey (bibtex-completion-get-value "=key=" candidate))
-          (suffix (s-lex-format "		(${citekey}, ${reftype}) ${tags}")))
+          (add (s-trim-right (s-join " " (list pdf note link))))
+          ; TODO: add separation between target and suffix
+          (suffix  (bibtex-completion-format-entry candidate (1- (frame-width))
+                        bibtex-completion-display-formats-suffix-internal)))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -80,9 +80,9 @@ may be indicated with the same icon but a different face."
 
 (when bibtex-actions-rich-ui
   (setq bibtex-completion-display-formats
-        '((t . "${author:20}   ${title:48}   ${year:4}")))
-  (setq bibtex-completion-display-formats-suffix
-        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
+        '((t . "${author:20}   ${title:48}   ${year:4}"))))
+  ;(setq bibtex-completion-display-formats-suffix
+  ;      '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
 
 
 ;;; Keymap
@@ -134,10 +134,20 @@ key associated with each one."
           (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
           (link (if (assoc "doi" (cdr candidate)) "has:link"))
           (citekey (bibtex-completion-get-value "=key=" candidate))
+          (reftype (bibtex-completion-get-value "=type=" candidate))
+          (keywords (or
+                     (bibtex-completion-get-value "tags" candidate)
+                     (bibtex-completion-get-value "keywords" candidate) ""))
           (add (s-trim-right (s-join " " (list pdf note link))))
-          ; TODO: add separation between target and suffix
-          (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
-                        bibtex-completion-display-formats-suffix)))
+          ; TODO: uncomment pending merge of
+          ;    https://github.com/tmalsburg/helm-bibtex/pull/367
+          ; (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
+          ;            bibtex-completion-display-formats-suffix)))
+          (suffix
+           (concat "     "
+            (truncate-string-to-width citekey 25 0 ?\s )
+            (truncate-string-to-width reftype 20 0 ?\s )
+            (truncate-string-to-width keywords 30 0 ?\s ))))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -137,7 +137,7 @@ key associated with each one."
           (add (s-trim-right (s-join " " (list pdf note link))))
           ; TODO: add separation between target and suffix
           (suffix (bibtex-completion-format-entry candidate (1- (frame-width))
-                        bibtex-completion-display-formats-suffix-internal)))
+                        bibtex-completion-display-formats-suffix)))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -56,16 +56,24 @@ in previous versions."
   "Face used to highlight suffixes in `bibtex-actions' candidates."
   :group 'bibtex-actions)
 
-(defcustom bibtex-actions-display-templates
+(defcustom bibtex-actions-display-template
   ; prefix will only work with rich ui, and on Emacs 28
   ; 'main' is the default entry display string
-  '((prefix . ((t . "${=has-pdf=:1} ${=has-note=:1}  ")))
-    (main   . ((t . "${author:20}   ${title:48}   ${year:4}")))
-    (suffix . ((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
+  '((t . "${author:20}   ${title:48}   ${year:4}"))
   "Configures display formatting for 'target', 'prefix' and 'suffix'.
 The latter two are optional, but are used in the 'rich ui'."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
+
+(defcustom bibtex-actions-display-template-suffix
+  ; prefix will only work with rich ui, and on Emacs 28
+  ; 'main' is the default entry display string
+  '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))
+  "Configures display formatting for 'target', 'prefix' and 'suffix'.
+The latter two are optional, but are used in the 'rich ui'."
+    :group 'bibtex-actions
+    :type  '(alist :key-type symbol :value-type function))
+
 
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
@@ -135,11 +143,6 @@ may be indicated with the same icon but a different face."
              ;; collect citation keys of selected candidate(s)
              collect (cdr (assoc choice candidates)))))
 
-(defun bibtex-actions--get-template (template-name)
-  "Use the TEMPLATE-NAME to grab the associated template."
-  (cadadr
-   (assoc template-name bibtex-actions-display-templates)))
-
 (defun bibtex-actions--get-candidates ()
   "Prepare candidates from 'bibtex-completion-candidates'.
 This both propertizes the candidates for display, and grabs the
@@ -157,7 +160,7 @@ key associated with each one."
            (bibtex-actions--format-entry
             candidate
             (1- (frame-width))
-            (bibtex-actions--get-template 'suffix))))
+            bibtex-actions-display-template-suffix)))
    (cons
     ;; Here use one string for display, and the other for search.
     ;; The candidate string we use is very long, which is a bit awkward
@@ -169,7 +172,7 @@ key associated with each one."
      (bibtex-actions--format-entry
       candidate
       (1- (frame-width))
-      (bibtex-actions--get-template 'main))
+      bibtex-actions-display-template)
      ;; Embed the suffix string as a custom property, for use in the affixation
      ;; function.
      'bibtex-actions-suffix suffix)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -134,7 +134,8 @@ key associated with each one."
           (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
           (link (if (assoc "doi" (cdr candidate)) "has:link"))
           (add (s-trim-right (s-join " " (list pdf note link))))
-          (tags (bibtex-completion-get-value "tags" candidate (or "")))
+          (tags (or (bibtex-completion-get-value "tags" candidate)
+                    (bibtex-completion-get-value "keywords" candidate) ""))
           (reftype (bibtex-completion-get-value "=type=" candidate))
           (citekey (bibtex-completion-get-value "=key=" candidate))
           (suffix (s-lex-format "		(${citekey}, ${reftype}) ${tags}")))
@@ -170,7 +171,7 @@ key associated with each one."
                              'face 'bibtex-actions-suffix)))
    (list candidate (concat
                     (s-join bibtex-actions-icon-separator
-                            (list pdf note link))"	") suffix))))
+                            (list pdf note))"	") suffix))))
 
 ;(defun bibtex-actions--make-suffix (entry)
 ;  "Create the formatted ENTRY suffix string for the 'rich-ui'."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -82,7 +82,7 @@ may be indicated with the same icon but a different face."
   (setq bibtex-completion-display-formats
         '((t . "${author:20}   ${title:48}   ${year:4}")))
   (setq bibtex-completion-display-formats-suffix
-        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:30}"))))
+        '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
 
 
 ;;; Keymap

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -60,8 +60,7 @@ in previous versions."
   ; prefix will only work with rich ui, and on Emacs 28
   ; 'main' is the default entry display string
   '((t . "${author:20}   ${title:48}   ${year:4}"))
-  "Configures display formatting for 'target', 'prefix' and 'suffix'.
-The latter two are optional, but are used in the 'rich ui'."
+  "Configures display formatting for the BibTeX entry."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
 
@@ -69,11 +68,9 @@ The latter two are optional, but are used in the 'rich ui'."
   ; prefix will only work with rich ui, and on Emacs 28
   ; 'main' is the default entry display string
   '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))
-  "Configures display formatting for 'target', 'prefix' and 'suffix'.
-The latter two are optional, but are used in the 'rich ui'."
+  "Configures display formatting for the BibTeX entry suffix."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
-
 
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
@@ -82,7 +79,7 @@ This should be a single character."
   :type 'string)
 
 (defcustom bibtex-actions-symbols
-  `((pdf .      (,bibtex-completion-pdf-symbol . " "))
+  `((pdf  .     (,bibtex-completion-pdf-symbol . " "))
     (note .     (,bibtex-completion-notes-symbol . " "))
     (link .     (,bibtex-actions-link-symbol . " ")))
   "Configuration alist specifying which symbol or icon to pick for a bib entry.
@@ -96,13 +93,6 @@ may be indicated with the same icon but a different face."
   "When using rich UI, the padding between prefix icons."
   :group 'bibtex-actions
   :type 'string)
-
-(when bibtex-actions-rich-ui
-  (setq bibtex-completion-display-formats
-        '((t . "${author:20}   ${title:48}   ${year:4}"))))
-  ;(setq bibtex-completion-display-formats-suffix
-  ;      '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))))
-
 
 ;;; Keymap
 


### PR DESCRIPTION
Add suffix UI, using the same configuration method as for the main display formatting.

Also add annotation-function, to provide the same UI pre-Emacs 28..

To enable this, I have adapted some code from bibtex-completion. I will 
that code, or greatly simplify it, if and when this PR is merged:

https://github.com/tmalsburg/helm-bibtex/pull/367

Closes #44

------

Here's what it looks like now, with these two PRs, and configured to use `all-the-icons`:

![Screenshot from 2021-03-26 11-04-25](https://user-images.githubusercontent.com/1134/112651865-3048a980-8e23-11eb-90cb-0c77d94dd5b6.png)
