### PR TITLE
trim-right candidate string

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -149,14 +149,15 @@ key associated with each one."
             (1- (frame-width))
             bibtex-actions-display-template-suffix)))
    (cons
-    (concat
-     ;; We need all of these searchable:
-     ;;   1. the 'display-string' variable to be displayed
-     ;;   2. the 'suffix-string' variable to be displayed with a different face
-     ;;   3. the 'add' variable to be hidden
-     (propertize display-string) " "
-     (propertize suffix-string 'face 'bibtex-actions-suffix) " "
-     (propertize add 'invisible t))
+    (s-trim-right
+     (concat
+      ;; We need all of these searchable:
+      ;;   1. the 'display-string' variable to be displayed
+      ;;   2. the 'suffix-string' variable to be displayed with a different face
+      ;;   3. the 'add' variable to be hidden
+      (propertize display-string) " "
+      (propertize suffix-string 'face 'bibtex-actions-suffix) " "
+      (propertize add 'invisible t)))
     citekey))))
 
 (defun bibtex-actions--affixation (cands)


### PR DESCRIPTION
As a general rule, when messing with the candidate strings, one must 
right trim, to remove trailing whitespace.

This ensures that multi candidate selection will work correctly with crm.

Fixes #52