### PR TITLE
remove bibtex-completion-init call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Compiled
+*.elc
+
+# Packaging
+.cask
+
+# Backup files
+*~
+
+# Undo-tree save-files
+*.~undo-tree

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -105,7 +105,6 @@ may be indicated with the same icon but a different face."
 ;;; Completion functions
 (defun bibtex-actions-read ()
   "Read bibtex-completion entries for completion using 'completing-read-multiple'."
-  (bibtex-actions--init)
   (when-let ((crm-separator "\\s-*&\\s-*")
              (candidates (bibtex-actions--get-candidates))
              (chosen
@@ -184,41 +183,6 @@ key associated with each one."
 ;;  NOTE this section will be removed, or dramatically simplified, if and
 ;;  when this PR is merged:
 ;;    https://github.com/tmalsburg/helm-bibtex/pull/367
-
-(defvar bibtex-actions--file-watch-descriptors nil
-  "List of path watches monitoring for changes.")
-
-(defun bibtex-actions--init ()
-  "Check that the files and directories specified by the user actually exist."
-
-  (let ((watch-these (bibtex-completion-normalize-bibliography)))
-
-    ;; Add PDF and notes paths to watch list.
-    (when bibtex-completion-library-path
-        (push bibtex-completion-library-path watch-these))
-    (when bibtex-completion-notes-path
-        (push bibtex-completion-notes-path watch-these))
-
-    ;; Remove current watch-descriptors:
-    (mapc (lambda (watch-descriptor)
-            (file-notify-rm-watch watch-descriptor))
-          bibtex-actions--file-watch-descriptors)
-    (setq bibtex-actions--file-watch-descriptors nil)
-
-    ;; Check that all specified files or directories exist and add
-    ;; watches for automatic reloading of the bibliography when a file
-    ;; or directory is changed:
-    (mapc
-     (lambda (path)
-       (if (f-exists? path)
-           (let ((watch-descriptor
-                  (file-notify-add-watch
-                   path '(change)
-                   'bibtex-completion-candidates)))
-             (setq bibtex-actions--file-watch-descriptors
-                   (cons watch-descriptor bibtex-actions--file-watch-descriptors)))
-         (user-error "%s path could not be found" path)))
-     (-flatten watch-these))))
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -214,7 +214,7 @@ key associated with each one."
            (let ((watch-descriptor
                   (file-notify-add-watch
                    path '(change)
-                   (lambda (_event) (bibtex-completion-candidates)))))
+                   'bibtex-completion-candidates)))
              (setq bibtex-actions--file-watch-descriptors
                    (cons watch-descriptor bibtex-actions--file-watch-descriptors)))
          (user-error "%s path could not be found" path)))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -185,20 +185,25 @@ key associated with each one."
 ;;  when this PR is merged:
 ;;    https://github.com/tmalsburg/helm-bibtex/pull/367
 
+(defvar bibtex-actions--file-watch-descriptors nil
+  "List of path watches monitoring for changes.")
+
 (defun bibtex-actions--init ()
   "Check that the files and directories specified by the user actually exist."
-  ;; Adapted from bibtex-completion.
+
   (let ((watch-these (bibtex-completion-normalize-bibliography)))
 
     ;; Add PDF and notes paths to watch list.
-    (push bibtex-completion-library-path watch-these)
-    (push bibtex-completion-notes-path watch-these)
+    (when bibtex-completion-library-path
+        (push bibtex-completion-library-path watch-these))
+    (when bibtex-completion-notes-path
+        (push bibtex-completion-notes-path watch-these))
 
     ;; Remove current watch-descriptors:
     (mapc (lambda (watch-descriptor)
             (file-notify-rm-watch watch-descriptor))
-          bibtex-completion-file-watch-descriptors)
-    (setq bibtex-completion-file-watch-descriptors nil)
+          bibtex-actions--file-watch-descriptors)
+    (setq bibtex-actions--file-watch-descriptors nil)
 
     ;; Check that all specified files or directories exist and add
     ;; watches for automatic reloading of the bibliography when a file
@@ -209,10 +214,10 @@ key associated with each one."
            (let ((watch-descriptor
                   (file-notify-add-watch
                    path '(change)
-                   (lambda () (bibtex-completion-candidates)))))
-             (setq bibtex-completion-file-watch-descriptors
-                   (cons watch-descriptor bibtex-completion-file-watch-descriptors)))
-           (user-error "%s path could not be found" path)))
+                   (lambda (_event) (bibtex-completion-candidates)))))
+             (setq bibtex-actions--file-watch-descriptors
+                   (cons watch-descriptor bibtex-actions--file-watch-descriptors)))
+         (user-error "%s path could not be found" path)))
      (-flatten watch-these))))
 
 (defun bibtex-actions--process-display-formats (formats)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -187,14 +187,12 @@ key associated with each one."
 
 (defun bibtex-actions--init ()
   "Check that the files and directories specified by the user actually exist."
-
+  ;; Adapted from bibtex-completion.
   (let ((watch-these (bibtex-completion-normalize-bibliography)))
 
     ;; Add PDF and notes paths to watch list.
-    ;; Could also make this configurable, if there was any concern
-    ;; about performance implications and such?
-    (cl-pushnew 'watch-these bibtex-completion-library-path)
-    (cl-pushnew 'watch-these bibtex-completion-notes-path)
+    (push bibtex-completion-library-path watch-these)
+    (push bibtex-completion-notes-path watch-these)
 
     ;; Remove current watch-descriptors:
     (mapc (lambda (watch-descriptor)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -105,7 +105,7 @@ may be indicated with the same icon but a different face."
 ;;; Completion functions
 (defun bibtex-actions-read ()
   "Read bibtex-completion entries for completion using 'completing-read-multiple'."
-  (bibtex-completion-init)
+  (bibtex-actions--init)
   (when-let ((crm-separator "\\s-*&\\s-*")
              (candidates (bibtex-actions--get-candidates))
              (chosen
@@ -184,6 +184,38 @@ key associated with each one."
 ;;  NOTE this section will be removed, or dramatically simplified, if and
 ;;  when this PR is merged:
 ;;    https://github.com/tmalsburg/helm-bibtex/pull/367
+
+(defun bibtex-actions--init ()
+  "Check that the files and directories specified by the user actually exist."
+
+  (let ((watch-these (bibtex-completion-normalize-bibliography)))
+
+    ;; Add PDF and notes paths to watch list.
+    ;; Could also make this configurable, if there was any concern
+    ;; about performance implications and such?
+    (cl-pushnew 'watch-these bibtex-completion-library-path)
+    (cl-pushnew 'watch-these bibtex-completion-notes-path)
+
+    ;; Remove current watch-descriptors:
+    (mapc (lambda (watch-descriptor)
+            (file-notify-rm-watch watch-descriptor))
+          bibtex-completion-file-watch-descriptors)
+    (setq bibtex-completion-file-watch-descriptors nil)
+
+    ;; Check that all specified files or directories exist and add
+    ;; watches for automatic reloading of the bibliography when a file
+    ;; or directory is changed:
+    (mapc
+     (lambda (path)
+       (if (f-exists? path)
+           (let ((watch-descriptor
+                  (file-notify-add-watch
+                   path '(change)
+                   (lambda () (bibtex-completion-candidates)))))
+             (setq bibtex-completion-file-watch-descriptors
+                   (cons watch-descriptor bibtex-completion-file-watch-descriptors)))
+           (user-error "%s path could not be found" path)))
+     (-flatten watch-these))))
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."


### PR DESCRIPTION
This initially started based on a misunderstanding of the `candidates` variable in the `bibtex-actions-read` function.

Given that the candidates are refreshed each time the function is run, instead go the opposite direction: remove any of this file-notify-based logic.

Can always revisit later if need be.