### PR TITLE
adjust widths to accommodate two sections

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -132,15 +132,17 @@ key associated with each one."
           (link (if (or (assoc "doi" (cdr candidate))
                         (assoc "url" (cdr candidate))) "has:link"))
           (citekey (bibtex-completion-get-value "=key=" candidate))
+          (main-width (* (frame-width) 0.65))
+          (suffix-width (* (frame-width) 0.34))
           (candidate-main
            (bibtex-actions--format-entry
             candidate
-            (1- (frame-width))
+            main-width
             bibtex-actions-template))
           (candidate-suffix
            (bibtex-actions--format-entry
             candidate
-            (1- (frame-width))
+            suffix-width
             bibtex-actions-template-suffix))
           ;; We display this content already using symbols; here we add back
           ;; text to allow it to be searched, and citekey to ensure uniqueness

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -132,8 +132,8 @@ key associated with each one."
           (link (if (or (assoc "doi" (cdr candidate))
                         (assoc "url" (cdr candidate))) "has:link"))
           (citekey (bibtex-completion-get-value "=key=" candidate))
-          (main-width (* (frame-width) 0.65))
-          (suffix-width (* (frame-width) 0.34))
+          (main-width (truncate (* (frame-width) 0.65)))
+          (suffix-width (truncate (* (frame-width) 0.34)))
           (candidate-main
            (bibtex-actions--format-entry
             candidate


### PR DESCRIPTION
With the addition of the suffix template, candidates were extending 
beyond the frame, which causes rendering oddness in some completion 
systems.

This fixes that, though does so currently using fixed ratios.