### PR TITLE
[WIP] make caching work correctly

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -84,9 +84,6 @@ may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type 'string)
 
-(defvar bibtex-actions--cache nil
-  "A cache that stores the results of 'bibtex-actions--get-candidates'.")
-
 ;;; Keymap
 
 (defvar bibtex-actions-map

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -106,7 +106,7 @@ may be indicated with the same icon but a different face."
 (defun bibtex-actions-read ()
   "Read bibtex-completion entries for completion using 'completing-read-multiple'."
   (when-let ((crm-separator "\\s-*&\\s-*")
-             (candidates (bibtex-actions--get-candidates))
+             (candidates (bibtex-completion-candidates))
              (chosen
               (completing-read-multiple
                "BibTeX entries: "
@@ -161,11 +161,11 @@ This propertizes the candidate for display and search."
   (cl-loop
    for entry in cands
    collect
-   ;; TODO change get-candidetes to accept a single CAND as input
-   (setcar entry 'bibtex-actions--transform-candidate)))
+   ;; TODO the key logic
+   (setcar entry (bibtex-actions--transform-candidate entry))))
 
-;; Add advice to replace candidate strings
 (advice-add 'bibtex-completion-candidates :filter-return #'bibtex-actions--advice)
+(advice-remove 'bibtex-completion-candidates #'bibtex-actions--advice)
 
 (defun bibtex-actions--affixation (cands)
   "Add affixation prefix to CANDS."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -84,6 +84,9 @@ may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type 'string)
 
+(defvar bibtex-actions--cache nil
+  "A cache that stores the results of 'bibtex-actions--get-candidates'.")
+
 ;;; Keymap
 
 (defvar bibtex-actions-map

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -127,6 +127,8 @@ may be indicated with the same icon but a different face."
   "Transform candidates from 'bibtex-completion-candidates'.
 This both propertizes the candidates for display, and grabs the
 key associated with each one."
+  ;; TODO refactor to 'add-advice' to use 'setcar' to replace
+  ;; 'bibtex-completion-candidates' car with this string.
   (cl-loop
    for candidate in (bibtex-completion-candidates)
    collect
@@ -162,6 +164,17 @@ key associated with each one."
       (propertize candidate-suffix 'face 'bibtex-actions-suffix) " "
       (propertize candidate-hidden 'invisible t)))
     citekey))))
+
+(defun bibtex-actions--advice (cands)
+  "The advice function to replace CANDS strings."
+  (cl-loop
+   for entry in cands
+   collect
+   ;; TODO change get-candidetes to accept a single CAND as input
+   (setcar entry 'bibtex-actions--get-candidates)))
+
+;; Add advice to replace candidate strings
+(advice-add 'bibtex-completion-candidates :filter-return #'bibtex-actions--advice)
 
 (defun bibtex-actions--affixation (cands)
   "Add affixation prefix to CANDS."


### PR DESCRIPTION
The bibtex-completion caching is based on `bibtex-completion-candidates`.

Seems like it should be working here, but according to #69 is not.

Edit: actually, not true (see below for details).

----

### Notes

Here's how `ivy-bibtex` does it:

``` elisp
(defun ivy-bibtex (&optional arg local-bib)
  "Search BibTeX entries using ivy.
With a prefix ARG the cache is invalidated and the bibliography
reread.
If LOCAL-BIB is non-nil, display that the BibTeX entries are read
from the local bibliography.  This is set internally by
`ivy-bibtex-with-local-bibliography'."
  (interactive "P")
  (when arg
    (bibtex-completion-clear-cache))
```