### PR TITLE
refactor: add candidates cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you happen to be using Doom Emacs, you can just add this to your `package.el`
 
 ### Basic
 
-Since all of the command logic resides in bibtex-completion, that is where to look for different [configuration options][bt-config]. 
+Since most of the command logic resides in bibtex-completion, that is where to look for different [configuration options][bt-config]. 
 
 The only thing, however, that you _must_ configure is where to find your bib file(s). 
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Here's how to configure it to use `all-the-icons`:
      :group 'all-the-icons-faces)
 ```
 
-### Proactive loading of library
+### Proactive reloading of library
 
 Bibtex-actions uses a cache to speed up library display. 
 This is great for performance, but means the data can become stale if you modify it. 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ The `bibtex-actions-refresh` command will reload the cache, and you can call thi
 You can also add `bibtex-completion`-style proactive loading by using `filenotify` something like this:
 
 ``` emacs-lisp
-(file-notify-add-watch bibtex-completion-bibliography
+;; Of course, you could also use `bibtex-complation-bibliography` here, but would need 
+;; to adapt this if you specify multiple files.
+(file-notify-add-watch "/path/to/file.bib"
                        '(change)
                        (lambda (event) (bibtex-actions-refresh)))
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To access these commands from `embark-act`, set this variable.
 ``` emacs-lisp
 (setf (alist-get 'bibtex embark-keymap-alist) 'bibtex-actions-map)
 ```
+
 ### Completion styles
 
 One of the beauties of the new suite of completing-read packages is the flexibility. 
@@ -96,6 +97,34 @@ Here's how to configure it to use `all-the-icons`:
      (((background light)) :foreground "#fafafa"))
      "Face for obscuring/dimming icons"
      :group 'all-the-icons-faces)
+```
+
+### Proactive loading of library
+
+Bibtex-actions uses a cache to speed up library display. 
+This is great for performance, but means the data can become stale if you modify it. 
+
+The `bibtex-actions-refresh` command will reload the cache, and you can call this manually. 
+
+You can also add `bibtex-completion`-style proactive loading by using `filenotify` something like this:
+
+``` emacs-lisp
+(file-notify-add-watch bibtex-completion-bibliography
+                       '(change)
+                       (lambda (event) (bibtex-actions-refresh)))
+```
+
+You can also extend this to do the same thing for your PDF files, or notes:
+
+``` emacs-lisp
+(file-notify-add-watch bibtex-completion-library-path
+                       '(change)
+                       (lambda (event) (bibtex-actions-refresh)))
+
+(file-notify-add-watch bibtex-completion-note-path
+                       '(change)
+                       (lambda (event) (bibtex-actions-refresh)))
+
 ```
 
 ## Usage

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -186,11 +186,11 @@ key associated with each one."
   "Store the candidates list.")
 
 (defun bibtex-actions--get-candidates ()
-    "Get the cached candidates.
+  "Get the cached candidates.
 If the cache is nil, this will load the cache."
-    (if (not bibtex-actions--candidates-cache)
-     (bibtex-actions--reload-candidates-cache))
-    bibtex-actions--candidates-cache)
+  (if (not bibtex-actions--candidates-cache)
+      (bibtex-actions--reload-candidates-cache))
+  bibtex-actions--candidates-cache)
 
 (defun bibtex-actions--reload-candidates-cache ()
   "Reload the candidates cache."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -191,7 +191,8 @@ key associated with each one."
   "Store the candidates list.")
 
 (defun bibtex-actions--get-candidates ()
-    "Load bib files and cache them."
+    "Get the cached candidates.
+If the cache is nil, this will load the cache."
     (if (not bibtex-actions--candidates-cache)
      (bibtex-actions--reload-candidates-cache))
     bibtex-actions--candidates-cache)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -189,11 +189,12 @@ key associated with each one."
   "Get the cached candidates.
 If the cache is nil, this will load the cache."
   (if (not bibtex-actions--candidates-cache)
-      (bibtex-actions--reload-candidates-cache))
+      (bibtex-actions-refresh))
   bibtex-actions--candidates-cache)
 
-(defun bibtex-actions--reload-candidates-cache ()
+(defun bibtex-actions-refresh ()
   "Reload the candidates cache."
+  (interactive)
   (setq bibtex-actions--candidates-cache
         (bibtex-actions--format-candidates)))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -120,7 +120,7 @@ may be indicated with the same icon but a different face."
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
 
-(defun bibtex-actions--get-candidates ()
+(defun bibtex-actions--format-candidates ()
   "Transform candidates from 'bibtex-completion-candidates'.
 This both propertizes the candidates for display, and grabs the
 key associated with each one."
@@ -186,6 +186,19 @@ key associated with each one."
 ;;  NOTE this section will be removed, or dramatically simplified, if and
 ;;  when this PR is merged:
 ;;    https://github.com/tmalsburg/helm-bibtex/pull/367
+
+(defvar bibtex-actions--candidates-cache nil
+  "Store the candidates list.")
+
+(defun bibtex-actions--get-candidates ()
+    "Load bib files and cache them."
+    (if (not bibtex-actions--candidates-cache)
+     (setq bibtex-actions--candidates-cache (bibtex-actions--format-candidates)))
+    bibtex-actions--candidates-cache)
+
+(defun bibtex-actions--clear-candidates-cache ()
+  "Clear the candidates cache."
+  (setq bibtex-actions--candidates-cache nil))
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -193,12 +193,12 @@ key associated with each one."
 (defun bibtex-actions--get-candidates ()
     "Load bib files and cache them."
     (if (not bibtex-actions--candidates-cache)
-     (setq bibtex-actions--candidates-cache (bibtex-actions--format-candidates)))
+     (bibtex-actions--reload-candidates-cache))
     bibtex-actions--candidates-cache)
 
-(defun bibtex-actions--clear-candidates-cache ()
-  "Clear the candidates cache."
-  (setq bibtex-actions--candidates-cache nil))
+(defun bibtex-actions--reload-candidates-cache ()
+  "Reload the candidates cache."
+  (setq bibtex-actions--candidates-cache (bibtex-actions--format-candidates)))
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -182,11 +182,6 @@ key associated with each one."
                     (s-join bibtex-actions-symbol-separator
                             (list pdf note link))"	") suffix))))
 
-;;; Formatting functions
-;;  NOTE this section will be removed, or dramatically simplified, if and
-;;  when this PR is merged:
-;;    https://github.com/tmalsburg/helm-bibtex/pull/367
-
 (defvar bibtex-actions--candidates-cache nil
   "Store the candidates list.")
 
@@ -199,7 +194,13 @@ If the cache is nil, this will load the cache."
 
 (defun bibtex-actions--reload-candidates-cache ()
   "Reload the candidates cache."
-  (setq bibtex-actions--candidates-cache (bibtex-actions--format-candidates)))
+  (setq bibtex-actions--candidates-cache
+        (bibtex-actions--format-candidates)))
+
+;;; Formatting functions
+;;  NOTE this section will be removed, or dramatically simplified, if and
+;;  when this PR is merged:
+;;    https://github.com/tmalsburg/helm-bibtex/pull/367
 
 (defun bibtex-actions--process-display-formats (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."


### PR DESCRIPTION
Refactor so that  `bibtex-actions-read` pulls candidates from a 
cache: `bibtex-actions--candidates-cache`.

Add:

- `bibtex-actions--candidates-cache` variable
- `bibtex-actions-refresh` interactive command, to update cache

Refactor:

-  `bibtex-actions--get-candidates` renamed to `bibtex-actions--format-candidates`
-  `bibtex-actions--get-candidates` now grabs the candidates from the cache

fixes #69

-----

@wenjie2wang - I do think it would also be good to add the hook to bibtex-completion, but you want to give this a try and let me know?

Turns out it was easier than I thought to add this.

But I haven't fully tested it and seen if it has any unintended consequences.

It does cache the candidates, however, so should address #69.

So if you could test it further and let me know, that'd be great.