### PR TITLE
refactor: convert candidates to use single format call

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -42,7 +42,7 @@
 ;;; Variables
 
 (defcustom bibtex-actions-template
-  '((t . "${author:20}   ${title:48}   ${year:4}"))
+  '((t . "${author:20}   ${title:48}   ${year:4} ${tags}"))
   "Configures formatting for the BibTeX entry.
 When combined with the suffix, the same string is used for
 display and for search."


### PR DESCRIPTION
At suggestion here: https://github.com/tmalsburg/helm-bibtex/pull/367#issuecomment-816120693

May be the only convenient way to address #67.

I'm getting a bit confused between this and #83, other than that idea with this one is to retain two templates, but combine them into a single format-entry call, and add the face to the result after.