### PR TITLE
revert UI to single display section

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -41,23 +41,10 @@
 
 ;;; Variables
 
-(defface bibtex-actions-suffix
-  '((t :inherit completions-annotations))
-  "Face used to highlight suffixes in `bibtex-actions' candidates."
-  :group 'bibtex-actions)
-
 (defcustom bibtex-actions-template
   '((t . "${author:20}   ${title:48}   ${year:4}"))
   "Configures formatting for the BibTeX entry.
 When combined with the suffix, the same string is used for
-display and for search."
-    :group 'bibtex-actions
-    :type  '(alist :key-type symbol :value-type function))
-
-(defcustom bibtex-actions-template-suffix
-  '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))
-  "Configures formatting for the BibTeX entry suffix.
-When combined wiht the main template, the same string is used for
 display and for search."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
@@ -124,14 +111,10 @@ may be indicated with the same icon but a different face."
   "Transform candidates from 'bibtex-completion-candidates'.
 This both propertizes the candidates for display, and grabs the
 key associated with each one."
-  (let* ((main-template
+  (let* ((template
          (bibtex-actions--process-display-formats
           bibtex-actions-template))
-         (suffix-template
-          (bibtex-actions--process-display-formats
-           bibtex-actions-template-suffix))
-         (main-width (truncate (* (frame-width) 0.65)))
-         (suffix-width (truncate (* (frame-width) 0.34))))
+         (width (1- (frame-width))))
     (cl-loop
      for candidate in (bibtex-completion-candidates)
      collect
@@ -140,16 +123,11 @@ key associated with each one."
             (link (if (or (assoc "doi" (cdr candidate))
                           (assoc "url" (cdr candidate))) "has:link"))
             (citekey (bibtex-completion-get-value "=key=" candidate))
-            (candidate-main
+            (formatted-candidate
              (bibtex-actions--format-entry
               candidate
-              main-width
-              main-template))
-            (candidate-suffix
-             (bibtex-actions--format-entry
-              candidate
-              suffix-width
-              suffix-template))
+              width
+              template))
             ;; We display this content already using symbols; here we add back
             ;; text to allow it to be searched, and citekey to ensure uniqueness
             ;; of the candidate.
@@ -158,14 +136,8 @@ key associated with each one."
         ;; If we don't trim the trailing whitespace, 'completing-read-multiple' will
         ;; get confused when there are multiple selected candidates.
         (s-trim-right
-         (concat
-          ;; We need all of these searchable:
-          ;;   1. the 'candidate-main' variable to be displayed
-          ;;   2. the 'candidate-suffix' variable to be displayed with a different face
-          ;;   3. the 'candidate-hidden' variable to be hidden
-          (propertize candidate-main) " "
-          (propertize candidate-suffix 'face 'bibtex-actions-suffix) " "
-          (propertize candidate-hidden 'invisible t)))
+          (concat formatted-candidate " "
+                  (propertize candidate-hidden 'invisible t)))
         citekey)))))
 
 (defun bibtex-actions--affixation (cands)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -42,7 +42,7 @@
 ;;; Variables
 
 (defcustom bibtex-actions-template
-  '((t . "${author:20}   ${title:48}   ${year:4}"))
+  '((t . "${author:20}   ${title:48}   ${year:4}   ${=type=:12}  ${tags:*}"))
   "Configures formatting for the BibTeX entry.
 When combined with the suffix, the same string is used for
 display and for search."
@@ -114,7 +114,7 @@ key associated with each one."
   (let* ((template
          (bibtex-actions--process-display-formats
           bibtex-actions-template))
-         (width (1- (frame-width))))
+         (width (1- (- (frame-width) 10))))
     (cl-loop
      for candidate in (bibtex-completion-candidates)
      collect

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -101,7 +101,6 @@ may be indicated with the same icon but a different face."
                  (if (eq action 'metadata)
                      `(metadata
                        (annotation-function . bibtex-actions--annotation)
-                       ;(affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
     (cl-loop for choice in chosen
@@ -141,15 +140,7 @@ key associated with each one."
                   (propertize candidate-hidden 'invisible t)))
         citekey)))))
 
-(defun bibtex-actions--affixation (cands)
-  "Add affixation prefix to CANDS."
-  ; TODO broken; either fix, or remove
-  (cl-loop
-   for candidate in cands
-   collect
-   candidate (bibtex-actions--annotation)))
-
-(defun bibtex-actions--annotation (candidate)
+(defun bibtex-actions--annotation (&optional candidate)
   "Add annotation to CANDIDATE."
    (let ((pdf (if (string-match "has:pdf" candidate)
                   (cadr (assoc 'pdf bibtex-actions-symbols))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -100,7 +100,8 @@ may be indicated with the same icon but a different face."
                (lambda (string predicate action)
                  (if (eq action 'metadata)
                      `(metadata
-                       (affixation-function . bibtex-actions--affixation)
+                       (annotation-function . bibtex-actions--annotation)
+                       ;(affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate))))))
     (cl-loop for choice in chosen
@@ -142,9 +143,14 @@ key associated with each one."
 
 (defun bibtex-actions--affixation (cands)
   "Add affixation prefix to CANDS."
+  ; TODO broken; either fix, or remove
   (cl-loop
    for candidate in cands
    collect
+   candidate (bibtex-actions--annotation)))
+
+(defun bibtex-actions--annotation (candidate)
+  "Add annotation to CANDIDATE."
    (let ((pdf (if (string-match "has:pdf" candidate)
                   (cadr (assoc 'pdf bibtex-actions-symbols))
                 (cddr (assoc 'pdf bibtex-actions-symbols))))
@@ -154,11 +160,10 @@ key associated with each one."
          (note
           (if (string-match "has:note" candidate)
                   (cadr (assoc 'note bibtex-actions-symbols))
-                (cddr (assoc 'note bibtex-actions-symbols))))
-         (suffix ""))
-   (list candidate (concat
-                    (s-join bibtex-actions-symbol-separator
-                            (list pdf note link))"	") suffix))))
+                (cddr (assoc 'note bibtex-actions-symbols)))))
+   (concat
+    (s-join bibtex-actions-symbol-separator
+            (list "  " pdf note link)))))
 
 (defvar bibtex-actions--candidates-cache nil
   "Store the candidates list.")


### PR DESCRIPTION
This is an experiment.

See #82 for context.

#80 is another approach that retains the main/suffix distinction, but with a different, more complex, approach.

In this case, there's only one template, and I've ditched affixation and instead used annotation. There are currently some spacing issues, but here's the basic idea:

![Screenshot from 2021-04-15 10-39-56](https://user-images.githubusercontent.com/1134/114888299-19b8c100-9dd7-11eb-8e22-881890d4a6d2.png)
