### PR TITLE
test: load local bibtex-actions.el on script

### DIFF
--- a/test/install.el
+++ b/test/install.el
@@ -25,7 +25,8 @@
 (package-install 'which-key)
 
 ;; bibtex-actions
-(package-install 'bibtex-actions)
+;; we load this locally, to facilitate development testing on branches
+(load "../bibtex-actions.el")
 
 ;; theme that supports selectrum and vertico
 (package-install 'modus-themes)


### PR DESCRIPTION
Instead of installing the `bibtex-actions` package from MELPA, now loads 
it locally.

This allows it to work for both users kicking the tires, and for 
developers wanting to run against a local branch.

Simple fix for #98.