### PR TITLE
Add org-cite function

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -64,7 +64,7 @@ display and for search."
 
 (defvar bibtex-actions-org-cite-commands
   ;; TODO make defcustom?
-  '("text" "year" "title" "author" "locators" "nocite" "plain")
+  '("text" "year" "title" "author" "locators" "nocite")
     "Org citation commands, and command descriptions.")
 
 (defcustom bibtex-actions-link-symbol "🔗"

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -62,9 +62,9 @@ display and for search."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
 
-(defcustom bibtex-actions-org-cite-commands
-  '("text" "year" "title" "author" "locators" "nocite")
-  "Org citation commands, and command descriptions."
+(defcustom bibtex-actions-org-cite-styles
+  '("text" "noauthor" "title" "author" "locators" "nocite")
+  "Org citation styles."
   :group 'bibtex-actions
   :type '(repeat string))
 
@@ -163,7 +163,7 @@ specific to the item, rather than the citation as a whole.
 
   [cite: see ;@key pp23-24]"
   (let* ((prefix  (if bibtex-completion-cite-prompt-for-optional-arguments (read-from-minibuffer "Prefix: ") ""))
-         (styles bibtex-actions-org-cite-commands)
+         (styles bibtex-actions-org-cite-styles)
          (style  (if bibtex-completion-cite-prompt-for-optional-arguments
                      (ido-completing-read "Style: " styles nil nil nil nil "default")))
          (prefix  (if (string= "" prefix)  "" (concat prefix  " ;")))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -62,10 +62,11 @@ display and for search."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
 
-(defvar bibtex-actions-org-cite-commands
-  ;; TODO make defcustom?
+(defcustom bibtex-actions-org-cite-commands
   '("text" "year" "title" "author" "locators" "nocite")
-    "Org citation commands, and command descriptions.")
+  "Org citation commands, and command descriptions."
+  :group 'bibtex-actions
+  :type '(repeat string))
 
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -62,6 +62,11 @@ display and for search."
     :group 'bibtex-actions
     :type  '(alist :key-type symbol :value-type function))
 
+(defvar bibtex-actions-org-cite-commands
+  ;; TODO make defcustom?
+  '("text" "year" "title" "author" "locators" "nocite" "plain")
+    "Org citation commands, and command descriptions.")
+
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
 This should be a single character."
@@ -84,6 +89,14 @@ may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type 'string)
 
+(setq bibtex-completion-format-citation-functions
+  '((org-mode      . bibtex-actions--format-citation-org)
+    (latex-mode    . bibtex-completion-format-citation-cite)
+    (markdown-mode . bibtex-completion-format-citation-pandoc-citeproc)
+    (python-mode   . bibtex-completion-format-citation-sphinxcontrib-bibtex)
+    (rst-mode      . bibtex-completion-format-citation-sphinxcontrib-bibtex)
+    (default       . bibtex-completion-format-citation-pandoc-citeproc)))
+
 ;;; Keymap
 
 (defvar bibtex-actions-map
@@ -102,6 +115,40 @@ may be indicated with the same icon but a different face."
     (define-key map (kbd "r") 'bibtex-actions-refresh)
     map)
   "Keymap for 'bibtex-actions'.")
+
+;;; Org-cite citation function
+
+(defun bibtex-actions--format-citation-org (keys)
+  "Format org-cite citations for the entries in KEYS.
+
+The full citation syntax is:
+
+  [cite/style:common prefix ;prefix @key suffix; ... ; common suffix]
+
+Everything is optional, except the brackets, 'cite' and the colon.
+Also the citation must contain at least a key.
+So its minimal form is:
+
+  [cite:@key]
+
+Note that the prefix here is for the citation as a whole; if you
+need to add one specific to an individual citation item, you
+would need to add that after inserting.
+
+  [cite:see ;item prefix @key]
+
+The same is true for suffixes like page numbers, which are
+specific to the item, rather than the citation as a whole.
+
+  [cite: see ;@key pp23-24]"
+  (let* ((prefix  (if bibtex-completion-cite-prompt-for-optional-arguments (read-from-minibuffer "Prefix: ") ""))
+         (styles bibtex-actions-org-cite-commands)
+         (style  (if bibtex-completion-cite-prompt-for-optional-arguments
+                     (ido-completing-read "Style: " styles nil nil nil nil "default")))
+         (prefix  (if (string= "" prefix)  "" (concat prefix  " ;")))
+         (style  (if (string-equal style "default") "" (concat "/" style))))
+    ;; this is derived from the pandoc syntax function, but this has two-levels of affixes
+    (format "[cite%s:%s%s]" style prefix (s-join ";" (--map (concat "@" it) keys)))))
 
 ;;; Completion functions
 (defun bibtex-actions-read ()


### PR DESCRIPTION
## Introduction

It looks like `org-cite` is close to merging.

https://lists.gnu.org/archive/html/emacs-orgmode/2021-04/msg00790.html

So this implements a function to format that syntax.

You can use this init file to test this with the org-cite branch code:

https://gist.github.com/bdarcus/2645f99363fc47ddab2aae24c5d9e66c

Here's what the style prompt looks like:

![Screenshot from 2021-05-06 09-00-34](https://user-images.githubusercontent.com/1134/117302445-a0e2dd00-ae49-11eb-90b7-ec76fe980704.png)


... with results when inserting into the `new-org-cite` org branch:

![Screenshot from 2021-05-03 13-50-04](https://user-images.githubusercontent.com/1134/116912675-87a61a80-ac16-11eb-8a17-40126609171b.png)

## Details

Bibtex-completion has flexible citation formatting functions.

Here is the default currently:

``` elisp
(defcustom bibtex-completion-format-citation-functions
  '((org-mode      . bibtex-completion-format-citation-ebib)
```

So this will hopefully replace `bibtex-completion-format-citation-ebib` as default.

I adapted this from the pandoc function, compared to which I have:

1. changed "prenote" to "prefix" to match `org-cite` language
2. removed "postnote" (because this is mostly used for things like page numbers, which are specific to an individual cite item; users will have to add this manually after insertion)
3. added `org-cite`-specific doc string and examples
4. defined a default style, which is ignored, and others, which are configurable, and which result in `[cite/text:@doe19;@doe20;@doe21]`.

## Issues

In general, I'm a little uncertain on the UX, but I have decided to keep this simple, and have users manually edit the inserted citation for more complex cases.

This is in part related to #91. It might be nice to support this with `completion-at-point`.

### Affixes

`Org-cite` has two-levels:

- one for the citation as a whole
- another for each individual citation within that.

I elected only to initially support prompting for the first, and only for the prefix.

### Styles

The styles currently overlap with those in the `oc-basic` POC, which may end up the fallback.

Regardless, I think merging this may have to wait on andras-simonyi/citeproc-org#16.

Closes #108.