### PR TITLE
Add filtering on open commands

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -105,7 +105,7 @@ may be indicated with the same icon but a different face."
 
 ;;; Completion functions
 (cl-defun bibtex-actions-read (&optional &key initial)
-  "Read bibtex-completion entries with INITIAL options.
+  "Read bibtex-completion entries with INITIAL option.
 
 This provides a wrapper around 'completing-read-multiple', with
 the following optional arguments:

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -128,8 +128,8 @@ the following optional arguments:
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
 
-(cl-defun bibtex-actions--filter (str)
-  "A predicate function to filter candidates not containing STR."
+(defun bibtex-actions--filter (candidate &optional str)
+  "A predicate function to filter a CANDIDATE not containing STR."
   ;; want to use 'get-property' to grab the 'hidden' string
   ;; or to generalize, may need more
   ;; along with 'seq-filter' or '-keep' or '-filter'

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -286,7 +286,7 @@ TEMPLATE."
 Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead."
-  (interactive (list (bibtex-actions-read :initial "has:link has:pdf")))
+  (interactive (list (bibtex-actions-read :initial "has:link has:pdf ")))
   (bibtex-completion-open-any keys))
 
 ;;;###autoload
@@ -294,13 +294,13 @@ PDF is found, try to open a URL or DOI in the browser instead."
  "Open PDF associated with the KEYS.
 If multiple PDFs are found, ask for the one to open using
 ‘completing-read’."
-  (interactive (list (bibtex-actions-read :initial "has:pdf")))
+  (interactive (list (bibtex-actions-read :initial "has:pdf ")))
   (bibtex-completion-open-pdf keys))
 
 ;;;###autoload
 (defun bibtex-actions-open-link (keys)
  "Open URL or DOI link associated with the KEYS in a browser."
- (interactive (list (bibtex-actions-read :initial "has:link")))
+ (interactive (list (bibtex-actions-read :initial "has:link ")))
  (bibtex-completion-open-url-or-doi keys))
 
 ;;;###autoload
@@ -336,7 +336,7 @@ If multiple PDFs are found, ask for the one to open using
 ;;;###autoload
 (defun bibtex-actions-open-notes (keys)
  "Open notes associated with the KEYS."
- (interactive (list (bibtex-actions-read :initial "has:note")))
+ (interactive (list (bibtex-actions-read :initial "has:note ")))
  (bibtex-completion-edit-notes keys))
 
 ;;;###autoload

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -104,14 +104,14 @@ may be indicated with the same icon but a different face."
   "Keymap for 'bibtex-actions'.")
 
 ;;; Completion functions
-(cl-defun bibtex-actions-read (&optional &key initial filter)
-  "Read bibtex-completion entries with INITIAL or FILTER OPTIONS.
+(cl-defun bibtex-actions-read (&optional &key initial)
+  "Read bibtex-completion entries with INITIAL options.
 
 This provides a wrapper around 'completing-read-multiple', with
 the following optional arguments:
 
-':initial': provides the initial value
-':filter': a 'predicate' function to filter the candidate list"
+':initial': provides the initial value, for pre-filtering the
+candidate list"
   (when-let ((crm-separator "\\s-*&\\s-*")
              (candidates (bibtex-actions--get-candidates))
              (chosen
@@ -123,17 +123,10 @@ the following optional arguments:
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate)))
-                 filter nil initial nil nil nil)))
+                 nil nil initial nil nil nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
-
-(defun bibtex-actions--filter (&optional candidate str)
-  "A predicate function to filter a CANDIDATE not containing STR."
-  ;; want to use 'get-property' to grab the 'hidden' string
-  ;; or to generalize, may need more
-  ;; along with 'seq-filter' or '-keep' or '-filter'
-  (message str))
 
 (defun bibtex-actions--format-candidates ()
   "Transform candidates from 'bibtex-completion-candidates'.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -128,7 +128,7 @@ the following optional arguments:
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
 
-(defun bibtex-actions--filter (candidate &optional str)
+(defun bibtex-actions--filter (&optional candidate str)
   "A predicate function to filter a CANDIDATE not containing STR."
   ;; want to use 'get-property' to grab the 'hidden' string
   ;; or to generalize, may need more

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -122,8 +122,8 @@ the following optional arguments:
                      `(metadata
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
-                   (complete-with-action action candidates string predicate))
-                 filter initial nil nil nil))))
+                   (complete-with-action action candidates string predicate)))
+                 filter nil initial nil nil nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -104,8 +104,14 @@ may be indicated with the same icon but a different face."
   "Keymap for 'bibtex-actions'.")
 
 ;;; Completion functions
-(defun bibtex-actions-read ()
-  "Read bibtex-completion entries for completion using 'completing-read-multiple'."
+(cl-defun bibtex-actions-read (&optional &key initial filter)
+  "Read bibtex-completion entries with INITIAL or FILTER OPTIONS.
+
+This provides a wrapper around 'completing-read-multiple', with
+the following optional arguments:
+
+':initial': provides the initial value
+':filter': a 'predicate' function to filter the candidate list"
   (when-let ((crm-separator "\\s-*&\\s-*")
              (candidates (bibtex-actions--get-candidates))
              (chosen
@@ -116,10 +122,18 @@ may be indicated with the same icon but a different face."
                      `(metadata
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
-                   (complete-with-action action candidates string predicate))))))
+                   (complete-with-action action candidates string predicate))
+                 filter initial nil nil nil))))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
+
+(cl-defun bibtex-actions--filter (str)
+  "A predicate function to filter candidates not containing STR."
+  ;; want to use 'get-property' to grab the 'hidden' string
+  ;; or to generalize, may need more
+  ;; along with 'seq-filter' or '-keep' or '-filter'
+  (message str))
 
 (defun bibtex-actions--format-candidates ()
   "Transform candidates from 'bibtex-completion-candidates'.
@@ -279,7 +293,7 @@ TEMPLATE."
 Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead."
-  (interactive (list (bibtex-actions-read)))
+  (interactive (list (bibtex-actions-read :initial "has:link has:pdf")))
   (bibtex-completion-open-any keys))
 
 ;;;###autoload
@@ -287,13 +301,13 @@ PDF is found, try to open a URL or DOI in the browser instead."
  "Open PDF associated with the KEYS.
 If multiple PDFs are found, ask for the one to open using
 ‘completing-read’."
-  (interactive (list (bibtex-actions-read)))
+  (interactive (list (bibtex-actions-read :initial "has:pdf")))
   (bibtex-completion-open-pdf keys))
 
 ;;;###autoload
 (defun bibtex-actions-open-link (keys)
  "Open URL or DOI link associated with the KEYS in a browser."
- (interactive (list (bibtex-actions-read)))
+ (interactive (list (bibtex-actions-read :initial "has:link")))
  (bibtex-completion-open-url-or-doi keys))
 
 ;;;###autoload
@@ -329,7 +343,7 @@ If multiple PDFs are found, ask for the one to open using
 ;;;###autoload
 (defun bibtex-actions-open-notes (keys)
  "Open notes associated with the KEYS."
- (interactive (list (bibtex-actions-read)))
+ (interactive (list (bibtex-actions-read :initial "has:note")))
  (bibtex-completion-edit-notes keys))
 
 ;;;###autoload


### PR DESCRIPTION
@apc - here's the start on #116.

It allows `bibtex-actions-read` to be called like this:

``` elisp
(bibtex-actions-read :initial "has:pdf")
```

So I changed the read function to include the `:initial` parameter, and also added the "initial-value" arguments to the relevant open commands.
