### PR TITLE
add bibtex-actions-history

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,7 +138,7 @@ Here's how to configure it to use =all-the-icons=:
 
 *** History and Predefined searches
 
-=Bibtex-actions= has functionality similar to the [[(https://github.com/tmalsburg/helm-bibtex#p][predefined search]] in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
+=Bibtex-actions= has functionality similar to the [[(https://github.com/tmalsburg/helm-bibtex#p][predefined search]] functionality in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
 Rather than create a new command with the search terms as argument, you just set the =bibtex-actions-presets= variable, and add the strings you want to access:
 
 #+begin_src emacs-lisp

--- a/README.org
+++ b/README.org
@@ -50,10 +50,16 @@ Bibtex-actions is available for installation from [[https://melpa.org][MELPA]].
 To setup bibtex-actions using =use-package=, you can simply do:
 
 #+BEGIN_SRC emacs-lisp
-  (use-package bibtex-actions
-    :config
-    ;; Make the 'bibtex-actions' bindings available from `embark-act'.
-    (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map)))
+(use-package bibtex-actions
+  :bind (("C-c b" . bibtex-actions-insert-citation)
+         :map minibuffer-local-map
+         ("M-b" . bibtex-actions-insert-preset))
+  :after embark
+  :config
+  ;; Make the 'bibtex-actions' bindings available from `embark-act'.
+  (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+  :custom
+  (bibtex-completion-bibliography '("~/bib/references.bib")))
 #+END_SRC
 
 Since most of the command logic resides in bibtex-completion, that is where to look for different [[https://github.com/tmalsburg/helm-bibtex#basic-configuration-recommended][configuration options]].

--- a/README.org
+++ b/README.org
@@ -136,6 +136,20 @@ Here's how to configure it to use =all-the-icons=:
        :group 'all-the-icons-faces)
 #+END_SRC
 
+*** History and Predefined searches
+
+=Bibtex-actions= has functionality similar to the [predefined search](https://github.com/tmalsburg/helm-bibtex#predefined-searches) feature in `helm-bibtex` and `ivy-bibtex`, but with a different implementation.
+Rather than create a new command with the search terms as argument, you just set the =bibtex-actions-presets= variable, and add the strings you want to access:
+
+#+begin_src emacs-lisp
+(setq bibtex-actions-presets '("one search string" "another search string"))
+#+end_src
+
+Internally, this is using the minibuffer "future history" functionality available in =completing-read=, which you access in =selectrum= by using =M-n= from the prompt.
+
+=Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), also accessible in =selectrum=, but by using =M-p=.
+You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
+
 *** Proactive reloading of library
     :PROPERTIES:
     :CUSTOM_ID: proactive-reloading-of-library

--- a/README.org
+++ b/README.org
@@ -138,7 +138,7 @@ Here's how to configure it to use =all-the-icons=:
 
 *** History and Predefined searches
 
-=Bibtex-actions= has functionality similar to the [[(https://github.com/tmalsburg/helm-bibtex#p][predefined search]] functionality in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
+=Bibtex-actions= has functionality similar to the [[https://github.com/tmalsburg/helm-bibtex#p][predefined search]] functionality in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
 Rather than create a new command with the search terms as argument, you just set the =bibtex-actions-presets= variable, and add the strings you want to access:
 
 #+begin_src emacs-lisp

--- a/README.org
+++ b/README.org
@@ -81,6 +81,7 @@ One of the beauties of the new suite of completing-read packages is the flexibil
 For =bibtex-actions= to work correctly, and as you may have come to expect in `helm-bibtex` or `ivy-bibtex`, you need to install and configure either prescient or orderless.
 You can read more about this at the [[https://github.com/raxod502/selectrum#usage][selectrum README]], but here's an example using orderless with its [[https://github.com/oantolin/orderless#style-dispatchers][style dispatchers]].
 
+
 #+CAPTION: orderless matching
 [[file:images/orderless.png]]
 

--- a/README.org
+++ b/README.org
@@ -157,9 +157,12 @@ Rather than create a new command with the search terms as argument, you just set
 (setq bibtex-actions-presets '("one search string" "another search string"))
 #+end_src
 
-Internally, this is using the minibuffer "future history" functionality available in =completing-read=, which you access in your completion UI by using =M-n= from the prompt.
+You then have two ways to access these strings from the completion prompt:
 
-=Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), also accessible in your completion UI, but by using =M-p=.
+1. by using =M-n= from the prompt, which will cycle through the strings
+2. by calling =bibtex-actions-insert-preset= with a keybinding, and then selecting the string
+
+=Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), which are also accessible in your completion UI, but by using =M-p=.
 You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
 
 *** Proactive reloading of library

--- a/README.org
+++ b/README.org
@@ -138,7 +138,7 @@ Here's how to configure it to use =all-the-icons=:
 
 *** History and Predefined searches
 
-=Bibtex-actions= has functionality similar to the [predefined search](https://github.com/tmalsburg/helm-bibtex#predefined-searches) feature in `helm-bibtex` and `ivy-bibtex`, but with a different implementation.
+=Bibtex-actions= has functionality similar to the [[(https://github.com/tmalsburg/helm-bibtex#p][predefined search]] in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
 Rather than create a new command with the search terms as argument, you just set the =bibtex-actions-presets= variable, and add the strings you want to access:
 
 #+begin_src emacs-lisp

--- a/README.org
+++ b/README.org
@@ -78,8 +78,8 @@ In particular, all of these work well:
     :CUSTOM_ID: completion-styles
     :END:
 One of the beauties of the new suite of completing-read packages is the flexibility.
-For =bibtex-actions= to work correctly, and as you may have come to expect in `helm-bibtex` or `ivy-bibtex`, you need to install and configure either prescient or orderless.
-You can read more about this at the [[https://github.com/raxod502/selectrum#usage][selectrum README]], but here's an example using orderless with its [[https://github.com/oantolin/orderless#style-dispatchers][style dispatchers]].
+For =bibtex-actions= to work correctly, and as you may have come to expect in =helm-bibtex= or =ivy-bibtex=, you need to install and configure either =prescient= or =orderless=.
+You can read more about this at the [[https://github.com/raxod502/selectrum#usage][selectrum README]], but here's an example using =orderless= with its [[https://github.com/oantolin/orderless#style-dispatchers][style dispatchers]].
 
 
 #+CAPTION: orderless matching
@@ -91,6 +91,7 @@ In this case, that search string is searching for all items without either a PDF
     :PROPERTIES:
     :CUSTOM_ID: test-script
     :END:
+
 The repository =test= directory also includes a script you can use to run this and associated packages in the =emacs -Q= sandbox.
 To do that, simply run =./run.sh= from the =test= directory.
 By default, this will use selectrum as the completion system.
@@ -156,9 +157,9 @@ Rather than create a new command with the search terms as argument, you just set
 (setq bibtex-actions-presets '("one search string" "another search string"))
 #+end_src
 
-Internally, this is using the minibuffer "future history" functionality available in =completing-read=, which you access in =selectrum= by using =M-n= from the prompt.
+Internally, this is using the minibuffer "future history" functionality available in =completing-read=, which you access in your completion UI by using =M-n= from the prompt.
 
-=Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), also accessible in =selectrum=, but by using =M-p=.
+=Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), also accessible in your completion UI, but by using =M-p=.
 You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
 
 *** Proactive reloading of library
@@ -248,8 +249,7 @@ This is inspired by =helm-bibtex= and =ivy-bibtex=, but is based on =completing-
 In comparison:
 
 - like =helm-bibtex=, but unlike =ivy-bibtex=, =bibtex-actions= has support for multi-selection of candidates
-- =helm-bibtex= and =ivy-bibtex= provide a single command, and the actions accessed from there; =bibtex-actions= provides all of its actions as standard commands, available from =M-x=, without a single
-  entry point.
+- =helm-bibtex= and =ivy-bibtex= provide a single command, and the actions accessed from there; =bibtex-actions= provides all of its actions as standard commands, available from =M-x=, without a single entry point.
 - =bibtex-actions= is based on =completing-read-multiple=, with a single dependency, and works with different completion systems (though in practice is best supported in =selectrum=) and supporting packages that are =completing-read= compliant; =helm-bibtex= and =ivy-bibtex= are based on =helm= and =ivy= respectively.
 
 ** Acknowledgements
@@ -263,4 +263,4 @@ This code takes those ideas and re-implements them to fill out the feature set, 
 
 Along the way, [[https://github.com/clemera][Clemens Radermacher]] and [[https://github.com/oantolin][Omar Antolín]] helped with some of the intricacies of completing-read and elisp.
 
-And, of course, thanks to [[https://github.com/tmalsburg][Titus von der Malburg]] for creating and maintaining bibtex-completion and helm-bibtex and ivy-bibtex.
+And, of course, thanks to [[https://github.com/tmalsburg][Titus von der Malburg]] for creating and maintaining =bibtex-completion= and =helm-bibtex= and =ivy-bibtex=.

--- a/README.org
+++ b/README.org
@@ -64,11 +64,21 @@ The only thing, however, that you /must/ configure is where to find your bib fil
   (setq bibtex-completion-bibliography "~/bib/references.bib")
 #+END_SRC
 
+*** Completion system
+
+=Bibtex-actions= uses the built-in =completing-read-multiple=, and so any vertical completion system that supports that should work.
+In particular, all of these work well:
+
+1. =selectrum=
+2. =vertico=
+3. =icomplete-vertical=
+
 *** Completion styles
     :PROPERTIES:
     :CUSTOM_ID: completion-styles
     :END:
 One of the beauties of the new suite of completing-read packages is the flexibility.
+For =bibtex-actions= to work correctly, and as you may have come to expect in `helm-bibtex` or `ivy-bibtex`, you need to install and configure either prescient or orderless.
 You can read more about this at the [[https://github.com/raxod502/selectrum#usage][selectrum README]], but here's an example using orderless with its [[https://github.com/oantolin/orderless#style-dispatchers][style dispatchers]].
 
 #+CAPTION: orderless matching

--- a/README.org
+++ b/README.org
@@ -69,9 +69,9 @@ The only thing, however, that you /must/ configure is where to find your bib fil
 =Bibtex-actions= uses the built-in =completing-read-multiple=, and so any vertical completion system that supports that should work.
 In particular, all of these work well:
 
-1. =selectrum=
-2. =vertico=
-3. =icomplete-vertical=
+1. [[https://github.com/raxod502/selectrum][selectrum]] (the most full-featured)
+2. [[https://github.com/minad/vertico][vertico]] (new, with a more minimal feature set)
+3. [[https://github.com/oantolin/icomplete-vertical][icomplete-vertical]] (for those that love icomplete, but want a vertical UI)
 
 *** Completion styles
     :PROPERTIES:

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -223,10 +223,14 @@ If the cache is nil, this will load the cache."
   (setq bibtex-actions--candidates-cache
         (bibtex-actions--format-candidates)))
 
+;;;###autoload
 (defun bibtex-actions-insert-preset ()
   "Prompt for and insert a predefined search."
   (interactive)
-  (when-let ((search (completing-read "Preset: " bibtex-actions-presets)))
+  (unless (minibufferp)
+    (user-error "Command can only be used in minibuffer"))
+  (when-let ((enable-recursive-minibuffers t)
+             (search (completing-read "Preset: " bibtex-actions-presets)))
     (insert search)))
 
 ;;; Formatting functions

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -306,7 +306,7 @@ TEMPLATE."
 Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead."
-  (interactive (list (bibtex-actions-read :initial "has:link has:pdf ")))
+  (interactive (list (bibtex-actions-read :initial "has:link\|has:pdf ")))
   (bibtex-completion-open-any keys))
 
 ;;;###autoload

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -133,7 +133,7 @@ candidate list"
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate)))
-                 nil nil initial 'bibtex-actions-history 'bibtex-actions-presets nil)))
+                 nil nil initial 'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -84,6 +84,9 @@ may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type 'string)
 
+(defvar bibtex-actions-history nil
+  "Search history for `bibtex-actions'.")
+
 ;;; Keymap
 
 (defvar bibtex-actions-map
@@ -123,7 +126,7 @@ candidate list"
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate)))
-                 nil nil initial nil nil nil)))
+                 nil nil initial 'bibtex-actions-history nil nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -84,8 +84,13 @@ may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type 'string)
 
+;;; History, including future history list.
+
 (defvar bibtex-actions-history nil
   "Search history for `bibtex-actions'.")
+
+(defcustom bibtex-actions-presets nil
+  "List of predefined searches.")
 
 ;;; Keymap
 
@@ -126,7 +131,7 @@ candidate list"
                        (affixation-function . bibtex-actions--affixation)
                        (category . bibtex))
                    (complete-with-action action candidates string predicate)))
-                 nil nil initial 'bibtex-actions-history nil nil)))
+                 nil nil initial 'bibtex-actions-history 'bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
@@ -215,6 +220,12 @@ If the cache is nil, this will load the cache."
   (interactive)
   (setq bibtex-actions--candidates-cache
         (bibtex-actions--format-candidates)))
+
+(defun bibtex-actions-insert-preset ()
+  "Prompt for and insert a predefined search."
+  (interactive)
+  (when-let ((search (completing-read "Preset: " bibtex-actions-presets)))
+    (insert search)))
 
 ;;; Formatting functions
 ;;  NOTE this section will be removed, or dramatically simplified, if and

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -90,7 +90,9 @@ may be indicated with the same icon but a different face."
   "Search history for `bibtex-actions'.")
 
 (defcustom bibtex-actions-presets nil
-  "List of predefined searches.")
+  "List of predefined searches."
+  :group 'bibtex-actions
+  :type '(repeat string))
 
 ;;; Keymap
 


### PR DESCRIPTION
This adds history support.

It also may address #119, per suggestion from @oantolin in https://github.com/bdarcus/bibtex-actions/issues/119#issuecomment-828810012.

> ... you can just prepopulate the history with the predefined searches, and people can use a command to search history with completion such as `consult-history`.

Two questions, @oantolin:

First, to "prepopulate the history", Is it really so simple as the below?

``` elisp
(setq bibtex-actions-history '("analysis" "chem"))
```

Second, how to activate the history?

If I run `consult-history`, for example, in any random buffer, I get a "no history configured" for that mode error.

Would this be something where I would just need to turn it on, for say, `text-mode`?? If yes, how? And in this package, or in a suggested README config?