### PR TITLE
Add prefix argument to force reloading of the cache

### DIFF
--- a/README.org
+++ b/README.org
@@ -171,17 +171,18 @@ You then have two ways to access these strings from the completion prompt:
 =Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), which are also accessible in your completion UI, but by using =M-p=.
 You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
 
-*** Proactive reloading of library
+*** Refreshing the library display
     :PROPERTIES:
-    :CUSTOM_ID: proactive-reloading-of-library
+    :CUSTOM_ID: refreshing-the-library-display
     :END:
 
 Bibtex-actions uses a cache to speed up library display.
 This is great for performance, but means the data can become stale if you modify it.
 
-The =bibtex-actions-refresh= command will reload the cache, and you can call this manually.
+The =bibtex-actions-refresh= command will reload the cache, and you can call this manually. 
+You can also call any of the `bibtex-actions` commands with a prefix argument: `C-u M-x bibtex-actions-insert-key`.
 
-You can also add =bibtex-completion=-style proactive loading by using =filenotify= something like this:
+Finally, another option is to add =bibtex-completion=-style proactive loading externally by using =filenotify= something like this:
 
 #+BEGIN_SRC emacs-lisp
   ;; Of course, you could also use `bibtex-completion-bibliography` here, but would need 

--- a/README.org
+++ b/README.org
@@ -180,7 +180,7 @@ Bibtex-actions uses a cache to speed up library display.
 This is great for performance, but means the data can become stale if you modify it.
 
 The =bibtex-actions-refresh= command will reload the cache, and you can call this manually. 
-You can also call any of the `bibtex-actions` commands with a prefix argument: `C-u M-x bibtex-actions-insert-key`.
+You can also call any of the `bibtex-actions` commands with a prefix argument: =C-u M-x bibtex-actions-insert-key=.
 
 Finally, another option is to add =bibtex-completion=-style proactive loading externally by using =filenotify= something like this:
 

--- a/README.org
+++ b/README.org
@@ -180,7 +180,7 @@ Bibtex-actions uses a cache to speed up library display.
 This is great for performance, but means the data can become stale if you modify it.
 
 The =bibtex-actions-refresh= command will reload the cache, and you can call this manually. 
-You can also call any of the `bibtex-actions` commands with a prefix argument: =C-u M-x bibtex-actions-insert-key=.
+You can also call any of the =bibtex-actions= commands with a prefix argument: =C-u M-x bibtex-actions-insert-key=.
 
 Finally, another option is to add =bibtex-completion=-style proactive loading externally by using =filenotify= something like this:
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -51,16 +51,16 @@
   "Configures formatting for the BibTeX entry.
 When combined with the suffix, the same string is used for
 display and for search."
-  :group 'bibtex-actions
-  :type  '(alist :key-type symbol :value-type function))
+    :group 'bibtex-actions
+    :type  '(alist :key-type symbol :value-type function))
 
 (defcustom bibtex-actions-template-suffix
   '((t . "          ${=key=:15}    ${=type=:12}    ${tags:*}"))
   "Configures formatting for the BibTeX entry suffix.
 When combined with the main template, the same string is used for
 display and for search."
-  :group 'bibtex-actions
-  :type  '(alist :key-type symbol :value-type function))
+    :group 'bibtex-actions
+    :type  '(alist :key-type symbol :value-type function))
 
 (defcustom bibtex-actions-link-symbol "🔗"
   "Symbol to indicate a DOI or URL link is available for a publication.
@@ -77,7 +77,7 @@ This leaves room for configurations where the absense of an item
 may be indicated with the same icon but a different face."
   :group 'bibtex-actions
   :type '(alist :key-type string
-		:value-type (choice (string :tag "Symbol"))))
+                :value-type (choice (string :tag "Symbol"))))
 
 (defcustom bibtex-actions-symbol-separator " "
   "The padding between prefix symbols."
@@ -115,79 +115,79 @@ may be indicated with the same icon but a different face."
 
 ;;; Completion functions
 (cl-defun bibtex-actions-read (&optional &key initial rebuild-cache)
-  "Read bibtex-completion entries with INITIAL option.
+  "Read bibtex-completion entries.
 
 This provides a wrapper around 'completing-read-multiple', with
 the following optional arguments:
 
-':initial': provides the initial value, for pre-filtering the
+'INITIAL' provides the initial value, for pre-filtering the
 candidate list
 
-':rebuild-cache': if t, force rebuilding the cache before
+'REBUILD-CACHE' if t, force rebuilding the cache before
 offering the selection candidates"
   (when-let ((crm-separator "\\s-*&\\s-*")
 	     (candidates (bibtex-actions--get-candidates rebuild-cache))
-	     (chosen
-	      (completing-read-multiple
-	       "BibTeX entries: "
-	       (lambda (string predicate action)
-		 (if (eq action 'metadata)
-		     `(metadata
-		       (affixation-function . bibtex-actions--affixation)
-		       (category . bibtex))
-		   (complete-with-action action candidates string predicate)))
-	       nil nil initial 'bibtex-actions-history bibtex-actions-presets nil)))
+             (chosen
+              (completing-read-multiple
+               "BibTeX entries: "
+               (lambda (string predicate action)
+                 (if (eq action 'metadata)
+                     `(metadata
+                       (affixation-function . bibtex-actions--affixation)
+                       (category . bibtex))
+                   (complete-with-action action candidates string predicate)))
+                 nil nil initial 'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
-	     ;; Collect citation keys of selected candidate(s).
-	     collect (cdr (assoc choice candidates)))))
+             ;; Collect citation keys of selected candidate(s).
+             collect (cdr (assoc choice candidates)))))
 
 (defun bibtex-actions--format-candidates ()
   "Transform candidates from 'bibtex-completion-candidates'.
 This both propertizes the candidates for display, and grabs the
 key associated with each one."
   (let* ((main-template
-	  (bibtex-actions--process-display-formats
-	   bibtex-actions-template))
-	 (suffix-template
-	  (bibtex-actions--process-display-formats
-	   bibtex-actions-template-suffix))
-	 (main-width (truncate (* (frame-width) 0.65)))
-	 (suffix-width (truncate (* (frame-width) 0.34))))
+         (bibtex-actions--process-display-formats
+          bibtex-actions-template))
+         (suffix-template
+          (bibtex-actions--process-display-formats
+           bibtex-actions-template-suffix))
+         (main-width (truncate (* (frame-width) 0.65)))
+         (suffix-width (truncate (* (frame-width) 0.34))))
     (cl-loop
      for candidate in (bibtex-completion-candidates)
      collect
      (let* ((pdf (if (assoc "=has-pdf=" (cdr candidate)) " has:pdf"))
-	    (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
-	    (link (if (or (assoc "doi" (cdr candidate))
-			  (assoc "url" (cdr candidate))) "has:link"))
-	    (citekey (bibtex-completion-get-value "=key=" candidate))
-	    (candidate-main
-	     (bibtex-actions--format-entry
-	      candidate
-	      main-width
-	      main-template))
-	    (candidate-suffix
-	     (bibtex-actions--format-entry
-	      candidate
-	      suffix-width
-	      suffix-template))
-	    ;; We display this content already using symbols; here we add back
-	    ;; text to allow it to be searched, and citekey to ensure uniqueness
-	    ;; of the candidate.
-	    (candidate-hidden (s-join " " (list pdf note link citekey))))
+            (note (if (assoc "=has-note=" (cdr candidate)) "has:note"))
+            (link (if (or (assoc "doi" (cdr candidate))
+                          (assoc "url" (cdr candidate))) "has:link"))
+            (citekey (bibtex-completion-get-value "=key=" candidate))
+            (candidate-main
+             (bibtex-actions--format-entry
+              candidate
+              main-width
+              main-template))
+            (candidate-suffix
+             (bibtex-actions--format-entry
+              candidate
+              suffix-width
+              suffix-template))
+            ;; We display this content already using symbols; here we add back
+            ;; text to allow it to be searched, and citekey to ensure uniqueness
+            ;; of the candidate.
+            (candidate-hidden (s-join " " (list pdf note link citekey))))
        (cons
-	;; If we don't trim the trailing whitespace, 'completing-read-multiple' will
-	;; get confused when there are multiple selected candidates.
-	(s-trim-right
-	 (concat
-	  ;; We need all of these searchable:
-	  ;;   1. the 'candidate-main' variable to be displayed
-	  ;;   2. the 'candidate-suffix' variable to be displayed with a different face
-	  ;;   3. the 'candidate-hidden' variable to be hidden
-	  (propertize candidate-main) " "
-	  (propertize candidate-suffix 'face 'bibtex-actions-suffix) " "
-	  (propertize candidate-hidden 'invisible t)))
-	citekey)))))
+        ;; If we don't trim the trailing whitespace, 'completing-read-multiple' will
+        ;; get confused when there are multiple selected candidates.
+        (s-trim-right
+         (concat
+          ;; We need all of these searchable:
+          ;;   1. the 'candidate-main' variable to be displayed
+          ;;   2. the 'candidate-suffix' variable to be displayed with a different face
+          ;;   3. the 'candidate-hidden' variable to be hidden
+          (propertize candidate-main) " "
+          (propertize candidate-suffix 'face 'bibtex-actions-suffix) " "
+          (propertize candidate-hidden 'invisible t)))
+        citekey)))))
 
 (defun bibtex-actions--affixation (cands)
   "Add affixation prefix to CANDS."
@@ -195,19 +195,19 @@ key associated with each one."
    for candidate in cands
    collect
    (let ((pdf (if (string-match "has:pdf" candidate)
-		  (cadr (assoc 'pdf bibtex-actions-symbols))
-		(cddr (assoc 'pdf bibtex-actions-symbols))))
-	 (link (if (string-match "has:link" candidate)
-		   (cadr (assoc 'link bibtex-actions-symbols))
-		 (cddr (assoc 'link bibtex-actions-symbols))))
-	 (note
-	  (if (string-match "has:note" candidate)
-	      (cadr (assoc 'note bibtex-actions-symbols))
-	    (cddr (assoc 'note bibtex-actions-symbols))))
-	 (suffix ""))
-     (list candidate (concat
-		      (s-join bibtex-actions-symbol-separator
-			      (list pdf note link))"	") suffix))))
+                  (cadr (assoc 'pdf bibtex-actions-symbols))
+                (cddr (assoc 'pdf bibtex-actions-symbols))))
+         (link (if (string-match "has:link" candidate)
+                   (cadr (assoc 'link bibtex-actions-symbols))
+                 (cddr (assoc 'link bibtex-actions-symbols))))
+         (note
+          (if (string-match "has:note" candidate)
+                  (cadr (assoc 'note bibtex-actions-symbols))
+                (cddr (assoc 'note bibtex-actions-symbols))))
+         (suffix ""))
+   (list candidate (concat
+                    (s-join bibtex-actions-symbol-separator
+                            (list pdf note link))"	") suffix))))
 
 (defvar bibtex-actions--candidates-cache nil
   "Store the candidates list.")
@@ -226,7 +226,7 @@ If FORCE-REBUILD-CACHE is t, force reloading the cache."
   "Reload the candidates cache."
   (interactive)
   (setq bibtex-actions--candidates-cache
-	(bibtex-actions--format-candidates)))
+        (bibtex-actions--format-candidates)))
 
 ;;;###autoload
 (defun bibtex-actions-insert-preset ()
@@ -235,7 +235,7 @@ If FORCE-REBUILD-CACHE is t, force reloading the cache."
   (unless (minibufferp)
     (user-error "Command can only be used in minibuffer"))
   (when-let ((enable-recursive-minibuffers t)
-	     (search (completing-read "Preset: " bibtex-actions-presets)))
+             (search (completing-read "Preset: " bibtex-actions-presets)))
     (insert search)))
 
 ;;; Formatting functions
@@ -250,18 +250,18 @@ If FORCE-REBUILD-CACHE is t, force reloading the cache."
    for format in formats
    collect
    (let* ((format-string (cdr format))
-	  (fields-width 0)
-	  (string-width
-	   (string-width
-	    (s-format
-	     format-string
-	     (lambda (field)
-	       (setq fields-width
-		     (+ fields-width
-			(string-to-number
-			 (or (cadr (split-string field ":"))
-			     ""))))
-	       "")))))
+          (fields-width 0)
+          (string-width
+           (string-width
+            (s-format
+             format-string
+             (lambda (field)
+               (setq fields-width
+                     (+ fields-width
+                        (string-to-number
+                         (or (cadr (split-string field ":"))
+                             ""))))
+               "")))))
      (-cons* (car format) format-string (+ fields-width string-width)))))
 
 (defun bibtex-actions--format-entry (entry width template)
@@ -270,44 +270,44 @@ WIDTH is the width of the results list, and the display format is governed by
 TEMPLATE."
   ;; Adapted from bibtex-completion.
   (let* ((format
-	  (or
-	   ;; If there's a template specific to the type, use that.
-	   (assoc-string
-	    (bibtex-completion-get-value "=type=" entry) template 'case-fold)
-	   ;; Otherwise, use the generic template.
-	   (assoc t template)))
-	 (format-string (cadr format)))
+          (or
+           ;; If there's a template specific to the type, use that.
+           (assoc-string
+            (bibtex-completion-get-value "=type=" entry) template 'case-fold)
+           ;; Otherwise, use the generic template.
+           (assoc t template)))
+         (format-string (cadr format)))
     (s-format
      format-string
      (lambda (field)
        (let* ((field (split-string field ":"))
-	      (field-name (car field))
-	      (field-width (cadr field))
-	      (field-value (bibtex-completion-get-value field-name entry)))
-	 (when (and (string= field-name "author")
-		    (not field-value))
-	   (setq field-value (bibtex-completion-get-value "editor" entry)))
-	 (when (and (string= field-name "year")
-		    (not field-value))
-	   (setq field-value (car (split-string (bibtex-completion-get-value "date" entry "") "-"))))
-	 (setq field-value (bibtex-completion-clean-string (or field-value " ")))
-	 (when (member field-name '("author" "editor"))
-	   (setq field-value (bibtex-completion-shorten-authors field-value)))
-	 (if (not field-width)
-	     field-value
-	   (setq field-width (string-to-number field-width))
-	   (let ((width (if (> field-width 0)
-			    ;; If user specifies field width of "*", use
-			    ;; WIDTH; else use the explicit 'field-width'.
-			    field-width
-			  width)))
-	     (truncate-string-to-width field-value width 0 ?\s))))))))
+              (field-name (car field))
+              (field-width (cadr field))
+              (field-value (bibtex-completion-get-value field-name entry)))
+         (when (and (string= field-name "author")
+                    (not field-value))
+           (setq field-value (bibtex-completion-get-value "editor" entry)))
+         (when (and (string= field-name "year")
+                    (not field-value))
+           (setq field-value (car (split-string (bibtex-completion-get-value "date" entry "") "-"))))
+         (setq field-value (bibtex-completion-clean-string (or field-value " ")))
+         (when (member field-name '("author" "editor"))
+           (setq field-value (bibtex-completion-shorten-authors field-value)))
+         (if (not field-width)
+             field-value
+           (setq field-width (string-to-number field-width))
+             (let ((width (if (> field-width 0)
+                              ;; If user specifies field width of "*", use
+                              ;; WIDTH; else use the explicit 'field-width'.
+                              field-width
+                            width)))
+               (truncate-string-to-width field-value width 0 ?\s))))))))
 
 ;;; Command wrappers for bibtex-completion functions
 
 ;;;###autoload
 (defun bibtex-actions-open (keys)
-  "Open PDF, or URL or DOI link.
+ "Open PDF, or URL or DOI link.
 Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead.
@@ -318,7 +318,7 @@ With prefix, rebuild the cache before offering candidates."
 
 ;;;###autoload
 (defun bibtex-actions-open-pdf (keys)
-  "Open PDF associated with the KEYS.
+ "Open PDF associated with the KEYS.
 If multiple PDFs are found, ask for the one to open using
 ‘completing-read’.
 With prefix, rebuild the cache before offering candidates."
@@ -332,14 +332,14 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :initial "has:link "
 					  :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-open-url-or-doi keys))
+ (bibtex-completion-open-url-or-doi keys))
 
 ;;;###autoload
 (defun bibtex-actions-insert-citation (keys)
   "Insert citation for the KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-insert-citation keys))
+ (bibtex-completion-insert-citation keys))
 
 ;;;###autoload
 (defun bibtex-actions-insert-reference (keys)
@@ -353,21 +353,21 @@ With prefix, rebuild the cache before offering candidates."
   "Insert BibTeX KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-insert-key keys))
+ (bibtex-completion-insert-key keys))
 
 ;;;###autoload
 (defun bibtex-actions-insert-bibtex (keys)
   "Insert BibTeX entry associated with the KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-insert-bibtex keys))
+ (bibtex-completion-insert-bibtex keys))
 
 ;;;###autoload
 (defun bibtex-actions-add-pdf-attachment (keys)
   "Attach PDF(s) associated with the KEYS to email.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-add-PDF-attachment keys))
+ (bibtex-completion-add-PDF-attachment keys))
 
 ;;;###autoload
 (defun bibtex-actions-open-notes (keys)
@@ -375,18 +375,18 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :initial "has:note "
 					  :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-edit-notes keys))
+ (bibtex-completion-edit-notes keys))
 
 ;;;###autoload
 (defun bibtex-actions-open-entry (keys)
   "Open BibTeX entry associated with the KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-show-entry keys))
+ (bibtex-completion-show-entry keys))
 
 ;;;###autoload
 (defun bibtex-actions-add-pdf-to-library (keys)
-  "Add PDF associated with the KEYS to library.
+ "Add PDF associated with the KEYS to library.
 The PDF can be added either from an open buffer, a file, or a
 URL.
 With prefix, rebuild the cache before offering candidates."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -123,7 +123,7 @@ the following optional arguments:
 'INITIAL' provides the initial value, for pre-filtering the
 candidate list
 
-'REBUILD-CACHE' if t, force rebuilding the cache before
+'REBUILD-CACHE' if t, forces rebuilding the cache before
 offering the selection candidates"
   (when-let ((crm-separator "\\s-*&\\s-*")
 	     (candidates (bibtex-actions--get-candidates rebuild-cache))


### PR DESCRIPTION
For all interactive functions, pass the prefix to `bibtex-read' to
allow optionally enforcing the reloading of the bibliography cache.

This is to avoid having to call `bibtex-actions-refresh` manually if the library file has been changed.
