### PR TITLE
fix: escape bug on regex

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -312,7 +312,7 @@ Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-read :initial "has:link\|has:pdf "
+  (interactive (list (bibtex-actions-read :initial "has:link\\|has:pdf "
 					  :rebuild-cache current-prefix-arg)))
   (bibtex-completion-open-any keys))
 


### PR DESCRIPTION
The default value on `bibtex-actions-open` was defined as:

```
has:pdf\|has:link
```

... but was inserted without the escape backslash.

This fixes that.