### PR TITLE
Customize initial input

### DIFF
--- a/README.org
+++ b/README.org
@@ -154,7 +154,10 @@ Here's how to configure it to use =all-the-icons=:
        :group 'all-the-icons-faces)
 #+END_SRC
 
-*** History and Predefined searches
+*** History and predefined searches
+    :PROPERTIES:
+    :CUSTOM_ID: history-and-predefined-searches
+    :END:
 
 =Bibtex-actions= has functionality similar to the [[https://github.com/tmalsburg/helm-bibtex#p][predefined search]] functionality in =helm-bibtex= and =ivy-bibtex=, but with a different implementation.
 Rather than create a new command with the search terms as argument, you just set the =bibtex-actions-presets= variable, and add the strings you want to access:
@@ -170,6 +173,33 @@ You then have two ways to access these strings from the completion prompt:
 
 =Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), which are also accessible in your completion UI, but by using =M-p=.
 You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
+
+*** Pre-filtering entries
+    :PROPERTIES:
+    :CUSTOM_ID: prefiltering-entries
+    :END:
+
+By default, =bibtex-actions= will, assuming you are using =orderless= or =prescient= to filter candidates, pre-filter entries for the following commands.
+
+1. =bibtex-actions-open=: pre-narrows the list to those which have associated pdf or links
+2. =bibtex-actions-open-link=: pre-narrows the list to those which have associated links
+3. =bibtex-actions-open-pdf=: -pre-narrows the list to those which have associated pdf(s)
+
+That is, upon running the command, an =initial-input= value will be inserted to narrow the results. 
+You can also delete that if you prefer to see the full list of candidates.
+
+By default, pre-filtering of =bibtex-actions-open-notes= is off, because the command by default will create a new note if none is available, and therefore it makes sense to have access to your full library. 
+But you can customize this to pre-filter if you prefer.
+
+If you want to modify those values, or remove them entirely, you can set =bibtex-actions-initial-inputs= like so; in this case turning off pre-filtering for =bibtex-actions-open-pdf=:
+
+#+begin_src elisp
+(setq bibtex-actions-initial-inputs
+  '((pdf    . nil)
+    (note   . nil)
+    (link   . "has:link")
+    (source . "has:link\\|has:pdf"))
+#+end_src
 
 *** Refreshing the library display
     :PROPERTIES:

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -97,6 +97,30 @@ manager like Zotero or JabRef."
   :group 'bibtex-actions
   :type '(repeat function))
 
+(defcustom bibtex-actions-initial-inputs
+  '((pdf    . "has:pdf")
+    (note   . "has:note")
+    (link   . "has:link")
+    (source . "has:link\\|has:pdf"))
+  "Alist defining the initial input for some bibtex open actions.
+Given a flexible completion style, this will restrict the list of
+available candidates to those matching the initial input.
+
+The association key can be one of the symbols `pdf', `note',
+`link' or `source' and defines the input for the function
+`bibtex-action-open-pdf', `bibtex-action-open-link', etc. The
+associated value must be nil, meaning that there will be no
+initial input, or a string.
+
+To match entries with certain properties (e.g. files attached),
+you can use the following initial inputs: \"has:pdf\",
+\"has:link\" and \"has:note\"."
+  :group 'bibtex-actions
+  :type '(alist :key-type symbol
+                :value-type (choice string
+                                    (const :tag "No initial input" nil))))
+
+  
 ;;; History, including future history list.
 
 (defvar bibtex-actions-history nil

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -108,7 +108,7 @@ available candidates to those matching the initial input.
 
 The association key can be one of the symbols `pdf', `note',
 `link' or `source' and defines the input for the function
-`bibtex-action-open-pdf', `bibtex-action-open-link', etc. The
+`bibtex-action-open-pdf', `bibtex-action-open-link', etc.  The
 associated value must be nil, meaning that there will be no
 initial input, or a string.
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -99,7 +99,7 @@ manager like Zotero or JabRef."
 
 (defcustom bibtex-actions-initial-inputs
   '((pdf    . "has:pdf")
-    (note   . "has:note")
+    (note   . nil)
     (link   . "has:link")
     (source . "has:link\\|has:pdf"))
   "Alist defining the initial input for some bibtex open actions.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -119,7 +119,6 @@ you can use the following initial inputs: \"has:pdf\",
   :type '(alist :key-type symbol
                 :value-type (choice string
                                     (const :tag "No initial input" nil))))
-
   
 ;;; History, including future history list.
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -157,13 +157,15 @@ you can use the following initial inputs: \"has:pdf\",
 This provides a wrapper around 'completing-read-multiple', with
 the following optional arguments:
 
-'INITIAL' provides the initial value, for pre-filtering the
-candidate list
+If 'INITIAL' matches one of the keys defined in
+`bibtex-actions-initial-inputs', use the associated initial
+input.
 
 'REBUILD-CACHE' if t, forces rebuilding the cache before
 offering the selection candidates"
   (let* ((crm-separator "\\s-*&\\s-*")
 	 (candidates (bibtex-actions--get-candidates rebuild-cache))
+         (initial-input (assoc-default initial bibtex-actions-initial-inputs))
          (chosen
           (completing-read-multiple
            "BibTeX entries: "
@@ -173,7 +175,12 @@ offering the selection candidates"
                    (affixation-function . bibtex-actions--affixation)
                    (category . bibtex))
                (complete-with-action action candidates string predicate)))
-           nil nil initial 'bibtex-actions-history bibtex-actions-presets nil)))
+           nil
+           nil
+           (and initial-input
+                (stringp initial-input)
+                (concat initial-input " "))
+           'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
              collect (cdr (assoc choice candidates)))))
@@ -354,7 +361,7 @@ Opens the PDF(s) associated with the KEYS.  If multiple PDFs are
 found, ask for the one to open using ‘completing-read’.  If no
 PDF is found, try to open a URL or DOI in the browser instead.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-read :initial "has:link\\|has:pdf "
+  (interactive (list (bibtex-actions-read :initial 'source
 					  :rebuild-cache current-prefix-arg)))
   (bibtex-completion-open-any keys))
 
@@ -364,7 +371,7 @@ With prefix, rebuild the cache before offering candidates."
 If multiple PDFs are found, ask for the one to open using
 ‘completing-read’.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-read :initial "has:pdf "
+  (interactive (list (bibtex-actions-read :initial 'pdf
 					  :rebuild-cache current-prefix-arg)))
   (bibtex-completion-open-pdf keys))
 
@@ -372,7 +379,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-open-link (keys)
   "Open URL or DOI link associated with the KEYS in a browser.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-read :initial "has:link "
+  (interactive (list (bibtex-actions-read :initial 'link
 					  :rebuild-cache current-prefix-arg)))
  (bibtex-completion-open-url-or-doi keys))
 
@@ -415,7 +422,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-open-notes (keys)
   "Open notes associated with the KEYS.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-read :initial "has:note "
+  (interactive (list (bibtex-actions-read :initial 'note
 					  :rebuild-cache current-prefix-arg)))
  (bibtex-completion-edit-notes keys))
 


### PR DESCRIPTION
Here's the PR for the customizable initial input. AFAIU, all other occurences of strings like "has:pdf" in the source code are used for actually inserting these strings in the candidates, so they should not be affected by that change.

Closes #129.