### PR TITLE
Add bibtex-actions-complete-key-at-point

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -234,12 +234,34 @@ If FORCE-REBUILD-CACHE is t, force reloading the cache."
     (bibtex-actions-refresh force-rebuild-cache))
   bibtex-actions--candidates-cache)
 
+(defun bibtex-actions-complete-key-at-point-org-cite ()
+    "Complete org-cite citation key at point.
+
+When inserting '@' in a buffer the capf UI will present user with
+a list of entries, from which they can narrow against a string
+which includes title, author, etc., and then select one.  This
+function will then return the key 'key', resulting in '@key' at
+point."
+  (when (eq ?@ (char-before))
+    (let* ((candidates (bibtex-actions--get-candidates))
+           ;; set both begin and end to point so we use capf UI to narrow and
+           ;; select
+           (begin (point))
+           (end (point)))
+      (list begin end candidates
+            :exit-function #'bibtex-actions--complete-key-at-point-exit-fn))))
+
+(defun bibtex-actions--complete-key-at-point-exit-fn (&optional str _status)
+  "Exit function to return key from a completion STR."
+    (let ((candidates (bibtex-actions--get-candidates)))
+      (delete-char (- (length str)))
+      (insert (cdr (assoc str candidates)))))
+
 ;;;###autoload
 (defun bibtex-actions-refresh (&optional force-rebuild-cache)
   "Reload the candidates cache.
 If called interactively with a prefix or if FORCE-REBUILD-CACHE
-is non-nil, also run the hook
-`bibtex-actions-before-refresh-hook'"
+is non-nil, also run the `bibtex-actions-before-refresh-hook' hook."
   (interactive "P")
   (when force-rebuild-cache
     (run-hooks 'bibtex-actions-force-refresh-hook))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -234,28 +234,31 @@ If FORCE-REBUILD-CACHE is t, force reloading the cache."
     (bibtex-actions-refresh force-rebuild-cache))
   bibtex-actions--candidates-cache)
 
-(defun bibtex-actions-complete-key-at-point-org-cite ()
-    "Complete org-cite citation key at point.
+(defun bibtex-actions-complete-key-at-point ()
+    "Complete org-cite or pandoc citation key at point.
 
-When inserting '@' in a buffer the capf UI will present user with
-a list of entries, from which they can narrow against a string
-which includes title, author, etc., and then select one.  This
-function will then return the key 'key', resulting in '@key' at
-point."
-  (when (eq ?@ (char-before))
-    (let* ((candidates (bibtex-actions--get-candidates))
-           ;; set both begin and end to point so we use capf UI to narrow and
-           ;; select
-           (begin (point))
-           (end (point)))
-      (list begin end candidates
-            :exit-function #'bibtex-actions--complete-key-at-point-exit-fn))))
+When inserting '@' in a buffer the capf UI will present a list of
+entries, from which the user can narrow against a string which
+includes title, author, etc., and then select one. This function
+will then return the key 'key', resulting in '@key' at point.
 
-(defun bibtex-actions--complete-key-at-point-exit-fn (&optional str _status)
-  "Exit function to return key from a completion STR."
-    (let ((candidates (bibtex-actions--get-candidates)))
-      (delete-char (- (length str)))
-      (insert (cdr (assoc str candidates)))))
+Supports the pandoc and 'org-cite' key syntax, in either
+'org-mode' or 'markdown-mode'."
+    ; FIX
+    (when ;(and (or (eq major-mode 'org-mode)
+         ;         (eq major-mode 'markdown-mode))
+               (eq ?@ (char-before))
+      (let* ((candidates (bibtex-actions--get-candidates))
+             ;; set both begin and end to point so we use capf UI to narrow and
+             ;; select
+             (begin (point))
+             (end (point)))
+        (list begin end candidates
+              :exit-function
+              (lambda (str _status)
+                ;; take completion str and replace with key
+                (delete-char (- (length str)))
+                (insert (cdr (assoc str candidates))))))))
 
 ;;;###autoload
 (defun bibtex-actions-refresh (&optional force-rebuild-cache)


### PR DESCRIPTION
Add a complete-at-point function, to complement `bibtex-actions-insert-citation`, targeting `org-cite`.

Some users may find this more efficient, in some cases. And we use the same candidates.

Basic completion works, with this the UI I'm looking for ...

![Screenshot from 2021-06-03 10-45-42](https://user-images.githubusercontent.com/1134/120664569-08944400-c459-11eb-943f-5b66422e4c39.png)

Current status is outlined here: https://github.com/bdarcus/bibtex-actions/pull/132#discussion_r656325631.

Aside: I did make a recommendation to include this in `org-cite` directly, though I imagine that may not get support. My idea was just to allow the candidates list to be configurable, so that using it with `bibtex-actions` would just involve something like:

``` elisp
(setq org-cite-capf-candidates (bibtex-actions--get-candidates))
```

See #91.