### PR TITLE
Add bibtex-actions-at-point

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -134,7 +134,12 @@ you can use the following initial inputs: \"has:pdf\",
   :type '(alist :key-type symbol
                 :value-type (choice string
                                     (const :tag "No initial input" nil))))
-  
+
+(defcustom bibtex-actions-default-action 'bibtex-actions-open
+  "The default action for the `bibtex-actions-at-point' command."
+  :group 'bibtex-actions
+  :type 'function)
+    
 ;;; History, including future history list.
 
 (defvar bibtex-actions-history nil
@@ -493,10 +498,12 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
   (bibtex-completion-add-pdf-to-library keys))
 
-(defvar bibtex-actions-default-action 'bibtex-actions-open)
-
 ;;;###autoload
 (defun bibtex-actions-at-point (keys)
+  "Select an action for the bibtex key at point.
+The bibtex key is found by `bibtex-completion-key-at-point', and
+the default action is set by `bibtex-actions-default-action'.
+With prefix, rebuild the cache before offering candidates."  
   (interactive (list (bibtex-actions-read :initial 'point
 					  :rebuild-cache current-prefix-arg)))
   (funcall bibtex-actions-default-action keys))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -115,13 +115,14 @@ manager like Zotero or JabRef."
   '((pdf    . "has:pdf")
     (note   . nil)
     (link   . "has:link")
-    (source . "has:link\\|has:pdf"))
+    (source . "has:link\\|has:pdf")
+    (point  . "bibtex-completion-key-at-point"))
   "Alist defining the initial input for some bibtex open actions.
 Given a flexible completion style, this will restrict the list of
 available candidates to those matching the initial input.
 
 The association key can be one of the symbols `pdf', `note',
-`link' or `source' and defines the input for the function
+`link', `source' or `point' and defines the input for the function
 `bibtex-action-open-pdf', `bibtex-action-open-link', etc.  The
 associated value must be nil, meaning that there will be no
 initial input, or a string.
@@ -227,7 +228,9 @@ offering the selection candidates"
            nil
            (and initial-input
                 (stringp initial-input)
-                (concat initial-input " "))
+                (if (string-equal initial-input "bibtex-completion-key-at-point")
+                    (bibtex-completion-key-at-point)
+                  (concat initial-input " ")))
            'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -493,5 +493,13 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-read :rebuild-cache current-prefix-arg)))
   (bibtex-completion-add-pdf-to-library keys))
 
+(defvar bibtex-actions-default-action 'bibtex-actions-open)
+
+;;;###autoload
+(defun bibtex-actions-at-point (keys)
+  (interactive (list (bibtex-actions-read :initial 'point
+					  :rebuild-cache current-prefix-arg)))
+  (funcall bibtex-actions-default-action keys))
+
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -116,7 +116,7 @@ manager like Zotero or JabRef."
     (note   . nil)
     (link   . "has:link")
     (source . "has:link\\|has:pdf")
-    (point  . "bibtex-completion-key-at-point"))
+    (point  . bibtex-completion-key-at-point))
   "Alist defining the initial input for some bibtex open actions.
 Given a flexible completion style, this will restrict the list of
 available candidates to those matching the initial input.
@@ -133,7 +133,8 @@ you can use the following initial inputs: \"has:pdf\",
   :group 'bibtex-actions
   :type '(alist :key-type symbol
                 :value-type (choice string
-                                    (const :tag "No initial input" nil))))
+                                    (const :tag "No initial input" nil)
+                                    (const :tag "Key at point" bibtex-completion-key-at-point))))
 
 (defcustom bibtex-actions-default-action 'bibtex-actions-open
   "The default action for the `bibtex-actions-at-point' command."
@@ -232,10 +233,9 @@ offering the selection candidates"
            nil
            nil
            (and initial-input
-                (stringp initial-input)
-                (if (string-equal initial-input "bibtex-completion-key-at-point")
-                    (bibtex-completion-key-at-point)
-                  (concat initial-input " ")))
+                (if (stringp initial-input)
+                    (concat initial-input " ")
+                  (funcall initial-input)))
            'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -499,14 +499,14 @@ With prefix, rebuild the cache before offering candidates."
   (bibtex-completion-add-pdf-to-library keys))
 
 ;;;###autoload
-(defun bibtex-actions-at-point (keys)
-  "Select an action for the bibtex key at point.
-The bibtex key is found by `bibtex-completion-key-at-point', and
-the default action is set by `bibtex-actions-default-action'.
-With prefix, rebuild the cache before offering candidates."  
-  (interactive (list (bibtex-actions-read :initial 'point
-					  :rebuild-cache current-prefix-arg)))
-  (funcall bibtex-actions-default-action keys))
+(defun bibtex-actions-at-point (&optional arg)
+  "Search BibTeX entries and call `bibtex-actions-default-action'.
+With prefix ARG, rebuild the cache before offering candidates.
+The bibtex key found by `bibtex-completion-key-at-point' is used
+as the initial input."
+  (interactive "P")
+  (funcall bibtex-actions-default-action
+           (bibtex-actions-read :initial 'point :rebuild-cache arg)))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here


### PR DESCRIPTION
This PR allows the bibtex key at point as initial input. Actions are available through `bibtex-actions-at-point` with `bibtex-actions-open` as the default.