### PR TITLE
Add bibtex-actions-get-key-org-cite

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -40,6 +40,7 @@
 (require 'bibtex-completion)
 
 (declare-function org-element-context "org-element")
+(declare-function org-element-property "org-element")
 
 ;;; Declare variables for byte compiler
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -38,6 +38,9 @@
 ;;; Code:
 
 (require 'bibtex-completion)
+(require 'org-element)
+
+(declare-function org-element-context "org-element")
 
 ;;; Declare variables for byte compiler
 
@@ -407,6 +410,15 @@ TEMPLATE."
                               field-width
                             width)))
                (truncate-string-to-width field-value width 0 ?\s))))))))
+
+;;; At-point functions
+
+(defun bibtex-completion-get-key-org-cite ()
+  "Return key at point for org-cite citation-reference."
+  (when (eq major-mode 'org-mode)
+    (let ((elt (org-element-context)))
+      (if (eq (car elt) 'citation-reference)
+          (org-element-property :key elt)))))
 
 ;;; Command wrappers for bibtex-completion functions
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -413,6 +413,8 @@ TEMPLATE."
 
 ;;; At-point functions
 
+;; This function will likely be removed if and when bibtex-completions adds
+;; something equivalent.
 (defun bibtex-actions-get-key-org-cite ()
   "Return key at point for org-cite citation-reference."
   (when (eq major-mode 'org-mode)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -413,7 +413,7 @@ TEMPLATE."
 
 ;;; At-point functions
 
-(defun bibtex-completion-get-key-org-cite ()
+(defun bibtex-actions-get-key-org-cite ()
   "Return key at point for org-cite citation-reference."
   (when (eq major-mode 'org-mode)
     (let ((elt (org-element-context)))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -38,7 +38,6 @@
 ;;; Code:
 
 (require 'bibtex-completion)
-(require 'org-element)
 
 (declare-function org-element-context "org-element")
 


### PR DESCRIPTION
Allows `bibtex-completions-at-point` to work with `org-cite`.

Are you OK with me adding this on your behalf, @ilupin?

Though it might be better to see if you can get it accepted to `bibtex-completion`?

cc @tmalsburg