### PR TITLE
Add `embark` support for citation keys at point

### DIFF
--- a/README.org
+++ b/README.org
@@ -306,7 +306,7 @@ From there, you can run different actions on the candidates at will, rather than
 
 =M-x bibtex-actions-at-point= will run the default action on citation keys found at point directly.
 
-By setting =bibtex-actions-embark-dwim= to nil, other actions in =bibtex-actions-buffer-map= will be prompted if =embark= is installed. Press =RET= will run the default action.
+If =embark= is installed, setting =bibtex-actions-embark-dwim= to nil will prompt for other actions in =bibtex-actions-buffer-map= . From there, pressing =RET= will run the default action.
 
 If no citation key is found, all items will be shown in the minibuffer for selection. This behavior can be disabled by setting =bibtex-actions-at-point-fallback= to nil.
 

--- a/README.org
+++ b/README.org
@@ -233,6 +233,25 @@ You can also extend this to do the same thing for your PDF files, or notes:
 
 For additional configuration options on this, see [[https://github.com/bdarcus/bibtex-actions/wiki/Configuration#automating-path-watches][the wiki]].
 
+*** Finding citation keys at point
+    :PROPERTIES:
+    :CUSTOM_ID: finding-citation-keys-at-point
+    :END:
+
+=bibtex-actions-at-point= can find citation keys at point in org-mode buffer, latex-mode buffer, etc. To add support for other major modes or citation syntax, you can write a function (below is an example for =org-cite=) and add it to =bibtex-completion-key-at-point-functions=.
+
+#+begin_src emacs-lisp
+(defun bibtex-actions-get-key-org-cite ()
+  "Return key at point for org-cite citation-reference."
+  (when-let (((eq major-mode 'org-mode))
+             (elt (org-element-context)))
+    (pcase (org-element-type elt)
+      ('citation-reference
+       (org-element-property :key elt))
+      ('citation
+       (org-cite-get-references elt t)))))
+#+end_src
+
 ** Usage
    :PROPERTIES:
    :CUSTOM_ID: usage
@@ -279,6 +298,17 @@ From there, you can run the same options discussed above using =embark-act= (whi
 
 So, for example, say you are working on a paper. You hold the complete super-set of items you are interested in citing at some point in that buffer.
 From there, you can run different actions on the candidates at will, rather than search individually for each item you want to cite.
+
+*** Use =bibtex-actions-at-point=
+    :PROPERTIES:
+    :CUSTOM_ID: use-bibtex-actions-at-point
+    :END:
+
+=M-x bibtex-actions-at-point= will run the default action on citation keys found at point directly.
+
+By setting =bibtex-actions-embark-dwim= to nil, other actions in =bibtex-actions-buffer-map= will be prompted if =embark= is installed. Press =RET= will run the default action.
+
+If no citation key is found, all items will be shown in the minibuffer for selection. This behavior can be disabled by setting =bibtex-actions-at-point-fallback= to nil.
 
 ** Comparisons
    :PROPERTIES:

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -585,7 +585,10 @@ With prefix ARG, rebuild the cache before offering candidates."
               ;; embark cannot pass TARGET to action when the action
               ;; is an interactive command
               (cl-letf (((symbol-function 'embark--act)
-                         (lambda (action target _) (funcall action target))))
+                         (lambda (action target _)
+                           (if (where-is-internal action (list bibtex-actions-buffer-map))
+                               (funcall action target)
+                             (command-execute action)))))
                 (if bibtex-actions-embark-dwim
                     (embark-dwim)
                   (embark-act))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -125,14 +125,13 @@ manager like Zotero or JabRef."
   '((pdf    . "has:pdf")
     (note   . nil)
     (link   . "has:link")
-    (source . "has:link\\|has:pdf")
-    (point  . bibtex-completion-key-at-point))
+    (source . "has:link\\|has:pdf"))
   "Alist defining the initial input for some bibtex open actions.
 Given a flexible completion style, this will restrict the list of
 available candidates to those matching the initial input.
 
 The association key can be one of the symbols `pdf', `note',
-`link', `source' or `point' and defines the input for the function
+`link' or `source' and defines the input for the function
 `bibtex-action-open-pdf', `bibtex-action-open-link', etc.  The
 associated value must be nil, meaning that there will be no
 initial input, or a string.
@@ -143,8 +142,7 @@ you can use the following initial inputs: \"has:pdf\",
   :group 'bibtex-actions
   :type '(alist :key-type symbol
                 :value-type (choice string
-                                    (const :tag "No initial input" nil)
-                                    (const :tag "Key at point" bibtex-completion-key-at-point))))
+                                    (const :tag "No initial input" nil))))
 
 (defcustom bibtex-actions-default-action 'bibtex-actions-open
   "The default action for the `bibtex-actions-at-point' command."
@@ -259,9 +257,8 @@ offering the selection candidates"
            nil
            nil
            (and initial-input
-                (if (stringp initial-input)
-                    (concat initial-input " ")
-                  (funcall initial-input)))
+                (stringp initial-input)
+                (concat initial-input " "))
            'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).


### PR DESCRIPTION
This PR enhances `embark` support for `bibtex-actions-at-point`, which is inspired by the discussion in #142 and the [code](https://github.com/bdarcus/bibtex-actions/pull/137#issuecomment-857456998) presented by @publicimageltd.

If `embark` is installed, `bibtex-actions-at-point` will call `embark-dwim` (the default) or `embark-act`, depending on the option `bibtex-actions-embark-dwim`, when one or more citation keys are found at point, where `embark-dwim` runs the default action and `embark-act` prompts the user for an action in `bibtex-actions-embark-map`. If no key is found, `bibtex-actions-read` is used for choosing entries, and functions in `bibtex-actions-map` can still be called via `embark-act`.

This PR uses `bibtex-actions-get-key-org-cite` and `bibtex-completion-key-at-point` to find citation keys, and should work with `org-cite` and latex-mode/bibtex-mode buffers.

<del>BTW, `embark-target-finders` requires the TARGET at point being a string, while `bibtex-completion-*` only accept a list of citation keys as input. Therefore, `bibtex-completion-*` cannot be used in `bibtex-actions-embark-map` directly, and `bibtex-actions-embark-*` does the argument conversion.</del>