### PR TITLE
docs: reorganization, capf documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -238,7 +238,8 @@ For additional configuration options on this, see [[https://github.com/bdarcus/b
     :CUSTOM_ID: finding-citation-keys-at-point
     :END:
 
-=bibtex-actions-at-point= can find citation keys at point in org-mode buffer, latex-mode buffer, etc. To add support for other major modes or citation syntax, you can write a function (below is an example for =org-cite=) and add it to =bibtex-completion-key-at-point-functions=.
+=bibtex-actions-at-point= can find citation keys at point in org-mode buffer, latex-mode buffer, etc.
+To add support for other major modes or citation syntax, you can write a function (below is an example for =org-cite=) and add it to =bibtex-completion-key-at-point-functions=.
 
 #+begin_src emacs-lisp
 (defun bibtex-actions-get-key-org-cite ()
@@ -259,7 +260,9 @@ For additional configuration options on this, see [[https://github.com/bdarcus/b
 
 You have a few different ways to interact with these commands.
 
-*** =M-x=
+*** Minibuffer actions
+
+**** =M-x=
     :PROPERTIES:
     :CUSTOM_ID: m-x
     :END:
@@ -279,27 +282,14 @@ These commands do allow you to select multiple items, with two caveats:
 1. For this to work correctly, you /must/ use the ampersand (=&=) as =crm-separator= to separate the candidates.
 2. We use long candidate strings, so if you use a completion system that requires you to =TAB=-complete, the experience is less-than-ideal.
 
-*** Access an alternate action via =embark-act=
-    :PROPERTIES:
-    :CUSTOM_ID: access-an-alternate-action-via-embark-act
-    :END:
+*** Buffer actions
 
-If while browsing you instead would rather edit that record, and you have embark installed and configured, this is where =embark-act= comes in.
-Simply input the keybinding for =embark-act= (in my case =C-o=), and select the alternate action.
+**** =bibtex-actions-insert-key-at-point=
 
-*** Use =embark-collect-snapshot=
-    :PROPERTIES:
-    :CUSTOM_ID: use-embark-collect-snapshot
-    :END:
+This completion function is an in-buffer complement to =bibtex-actions-insert-citation=, for use with =corfu= or =company=, and uses the same cached completion data.
+Performance and UI should thus be consistent across the two interfaces.
 
-A final option, that can be useful: run =embark-collect-snapshot= (=S=) from =embark-act=.
-This will select the candidate subset, and open it in a separate buffer.
-From there, you can run the same options discussed above using =embark-act= (which is also bound to =a= in the collect buffer).
-
-So, for example, say you are working on a paper. You hold the complete super-set of items you are interested in citing at some point in that buffer.
-From there, you can run different actions on the candidates at will, rather than search individually for each item you want to cite.
-
-*** Use =bibtex-actions-at-point=
+**** =bibtex-actions-at-point=
     :PROPERTIES:
     :CUSTOM_ID: use-bibtex-actions-at-point
     :END:
@@ -309,6 +299,33 @@ From there, you can run different actions on the candidates at will, rather than
 If =embark= is installed, setting =bibtex-actions-embark-dwim= to nil will prompt for other actions in =bibtex-actions-buffer-map= . From there, pressing =RET= will run the default action.
 
 If no citation key is found, all items will be shown in the minibuffer for selection. This behavior can be disabled by setting =bibtex-actions-at-point-fallback= to nil.
+
+
+*** Embark
+
+If configured, =embark= binds contextual actions to completion candidates in the minibuffer, and to citation keys in the buffer.
+
+**** Access an alternate action via =embark-act=
+    :PROPERTIES:
+    :CUSTOM_ID: access-an-alternate-action-via-embark-act
+    :END:
+
+If while browsing you instead would rather edit that record, and you have embark installed and configured, this is where =embark-act= comes in.
+Simply input the keybinding for =embark-act= (in my case =C-o=), and select the alternate action.
+
+**** Use =embark-collect-snapshot=
+    :PROPERTIES:
+    :CUSTOM_ID: use-embark-collect-snapshot
+    :END:
+
+A final option, that can be useful: run =embark-collect-snapshot= (=S=) from =embark-act=.
+This will select the candidate subset, and open it in a separate buffer.
+From there, you can run the same options discussed above using =embark-act= (which is also bound to =a= in the collect buffer).
+
+So, for example, say you are working on a paper.
+You hold the complete super-set of items you want to cite at some point in that buffer.
+From there, you can run different actions on the candidates at will, rather than search individually for each item you want to cite.
+
 
 ** Comparisons
    :PROPERTIES:


### PR DESCRIPTION
Followup to #132.

I am reorganizing the README a bit with the addition of the capf and the at-point stuff @ilupin worked on.

Idea is to have three main "usage" subsections:

1. minibuffer actions
2. buffer actions
3. embark (since it does both)

I'll still need to figure out some details. It may be that in the process of this, I need to do a more extensive reorg!