### PR TITLE
Enhance CRM selection UI

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -61,6 +61,11 @@
   "Face used to highlight suffixes in `bibtex-actions' candidates."
   :group 'bibtex-actions)
 
+(defface bibtex-actions-crm-display-face
+  '((t (:box '(:line-width 6 :color "gray20"))))
+  "Face used to highlightened shortened candidate strings in crm prompt."
+  :group 'bibtex-actions)
+
 (defcustom bibtex-actions-template
   '((t . "${author:20}   ${title:48}   ${year:4}"))
   "Configures formatting for the BibTeX entry.
@@ -262,7 +267,8 @@ offering the selection candidates"
                                       (when-let (short (cdr (assoc (string-trim (buffer-substring-no-properties
                                                                                  pos (match-beginning 0)))
                                                                    candidates)))
-                                        (put-text-property pos (match-beginning 0) 'display short))
+                                        (add-text-properties pos (match-beginning 0)
+                                                             `(display ,(propertize short 'face 'bibtex-actions-crm-display-face))))
                                       (setq pos (point))))))))
                           nil 'local))
             (completing-read-multiple


### PR DESCRIPTION
Addresses #135.

Basic idea is to hack the minibuffer to present shortened candidate strings in the CRM prompt, and so address the primary UI problem.

Issues:

1. how well does it actually work? there are currently some UI oddities (see below; after inserting multiple in vertico, there's no space or separator between them, and I can't "remove" them from the prompt). Seems one improvement would be adding a face to the selected candidates, so in this case they would have a light gray background, and some spacing between them.
2. it does work in Vertico; but Selectrum is problematic ATM (the candidates don't show up in the prompt, and cursor drops to the bottom of the screen)
3. but Vertico has other CRM UI issues (see below).

![Screenshot from 2021-06-30 10-36-37](https://user-images.githubusercontent.com/1134/123979932-2341d600-d98f-11eb-8dea-c27c1b89e71b.png)
