### PR TITLE
Add more format-keys function

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -455,10 +455,8 @@ TEMPLATE."
   "Formatter for KEYS.
 Adds an @ prefix and a semi-colon delimiter for 'org-mode' and 'markdown-mode'.
 Otherwise, keys are plain and comma-delimited."
-  (let* ((prefix (when (or (eq major-mode 'org-mode)
-                           (eq major-mode 'markdown-mode) "@")))
-         (delimiter (if (or (eq major-mode 'org-mode)
-                            (eq major-mode 'markdown-mode) ";")
+  (let* ((prefix (if (eq major-mode 'org-mode) "@" ""))
+         (delimiter (if (eq major-mode 'markdown-mode) ";"
                         ",")))
          (mapconcat (lambda (k) (concat prefix k)) keys delimiter)))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -111,7 +111,7 @@ may be indicated with the same icon but a different face."
     (markdown-mode . bibtex-completion-format-citation-pandoc-citeproc)
     (python-mode   . bibtex-completion-format-citation-sphinxcontrib-bibtex)
     (rst-mode      . bibtex-completion-format-citation-sphinxcontrib-bibtex)
-    (default       . bibtex-completion-format-citation-pandoc-citeproc)))
+    (default       . bibtex-actions-format-keys)))
 
 (defcustom bibtex-actions-force-refresh-hook nil
   "Hook run when user forces a (re-) building of the candidates cache.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -449,6 +449,19 @@ TEMPLATE."
                             width)))
                (truncate-string-to-width field-value width 0 ?\s))))))))
 
+;;; Custom formatting functions
+
+(defun bibtex-actions-format-keys (keys)
+  "Formatter for KEYS.
+Adds an @ prefix and a semi-colon delimiter for 'org-mode' and 'markdown-mode'.
+Otherwise, keys are plain and comma-delimited."
+  (let* ((prefix (when (or (eq major-mode 'org-mode)
+                           (eq major-mode 'markdown-mode) "@")))
+         (delimiter (if (or (eq major-mode 'org-mode)
+                            (eq major-mode 'markdown-mode) ";")
+                        ",")))
+         (mapconcat (lambda (k) (concat prefix k)) keys delimiter)))
+
 ;;; At-point functions
 
 ;;; Org-cite


### PR DESCRIPTION
The bibtex-completion one only works for latex. This adds org-cite and pandoc.

Not sure this is needed with `bibtex-actions-org-cite`.