### PR TITLE
Add oc-insert processor

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ Bibtex-actions is available for installation from [[https://melpa.org][MELPA]].
     :CUSTOM_ID: basic
     :END:
 
-To setup bibtex-actions using =use-package=, you can simply do:
+To setup bibtex-actions using =use-package=, you can do:
 
 #+BEGIN_SRC emacs-lisp
 (use-package bibtex-actions
@@ -69,6 +69,25 @@ The only thing, however, that you /must/ configure is where to find your bib fil
 #+BEGIN_SRC emacs-lisp
   (setq bibtex-completion-bibliography "~/bib/references.bib")
 #+END_SRC
+
+*** Org-Cite
+
+Bibtex-actions includes org-cite integration via a processor with "follow" and "insert" capabilities.
+To configure those, you can do:
+
+#+BEGIN_SRC emacs-lisp
+(setq org-cite-follow-processor 'bibtex-actions)
+(setq org-cite-insert-processor 'bibtex-actions)
+#+END_SRC
+
+By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you do =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.
+If you have Embark installed and configured, however, setting this variable will invoke =embark-act= instead.
+
+#+BEGIN_SRC emacs-lisp
+(setq bibtex-actions-embark-dwim nil)
+#+END_SRC
+
+
 
 *** Completion system
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -44,6 +44,8 @@
 (declare-function org-element-type "org-element")
 (declare-function org-cite-get-references "org-cite")
 (declare-function org-cite-register-processor "org-cite")
+(declare-function org-cite-make-insert-processor "org-cite")
+(declare-function org-cite-basic--complete-style "org-cite")
 (declare-function embark-act "embark")
 
 ;;; Declare variables for byte compiler
@@ -465,9 +467,20 @@ TEMPLATE."
       ('citation
        (org-cite-get-references elt t)))))
 
-;; "follow" processor
+;; Org-cite "follow" and "insert" processor
+
+(defun bibtex-actions-org-cite-insert ()
+  "Return a list keys, or a key string."
+  (let ((references (bibtex-actions-read)))
+    (if (< 1 (length references))
+        references
+      (car references))))
+
 (when (require 'oc nil t)
   (org-cite-register-processor 'bibtex-actions
+    :insert (org-cite-make-insert-processor
+             #'bibtex-actions-org-cite-insert
+             #'org-cite-basic--complete-style)
     :follow (lambda (_datum _arg) (call-interactively 'bibtex-actions-at-point))))
 
 ;;; Embark

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -469,10 +469,10 @@ TEMPLATE."
 
 ;; Org-cite "follow" and "insert" processor
 
-(defun bibtex-actions-org-cite-insert ()
-  "Return a list keys, or a key string."
+(defun bibtex-actions-org-cite-insert (multiple)
+  "Return a list of keys when MULTIPLE, or else a key string."
   (let ((references (bibtex-actions-read)))
-    (if (< 1 (length references))
+    (if multiple
         references
       (car references))))
 


### PR DESCRIPTION
Makes `bibtex-actions-read` available as an "insert processor".

``` elisp
(setq org-cite-insert-processor 'bibtex-actions)
```