### PR TITLE
fix embark at-point

### DIFF
--- a/README.org
+++ b/README.org
@@ -75,14 +75,17 @@ To configure those, you can do:
 (setq org-cite-insert-processor 'bibtex-actions)
 #+END_SRC
 
-By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you do =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.
+The "insert processor" will use =bibtex-actions-read= to browse your library to insert and edit citations and citation references using the =org-cite-insert= command.
+
+The "follow processor" provides at-point functionality accessible via the =org-open-at-point= command.
+By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you invoke =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.
 If you have Embark installed and configured, however, setting this variable will invoke =embark-act= instead.
 
 #+BEGIN_SRC emacs-lisp
 (setq bibtex-actions-embark-dwim nil)
 #+END_SRC
 
-
+You can invoke both =embark-act= and =embark-dwim=, however, independently of =org-at-point=, and in other modes such as =latex-mode=.
 
 *** Completion system
 
@@ -330,9 +333,11 @@ From there, you can run different actions on the candidates at will, rather than
 
 =M-x bibtex-actions-at-point= will run the default action on citation keys found at point directly.
 
-If =embark= is installed, setting =bibtex-actions-embark-dwim= to nil will prompt for other actions in =bibtex-actions-buffer-map= . From there, pressing =RET= will run the default action.
+If you have =embark= installed, setting =bibtex-actions-embark-dwim= to nil will substitute =embark=act=, and so prompt for other actions in =bibtex-actions-buffer-map=.
+From there, pressing =RET= will run the default action.
 
-If no citation key is found, all items will be shown in the minibuffer for selection. This behavior can be disabled by setting =bibtex-actions-at-point-fallback= to nil.
+If no citation key is found, the minibuffer will open for selection.
+You can disable this behavior by setting =bibtex-actions-at-point-fallback= to nil.
 
 ** Comparisons
    :PROPERTIES:

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -470,7 +470,7 @@ TEMPLATE."
 
 ;; Org-cite "follow" and "insert" processor
 
-(defun bibtex-actions-org-cite-insert (multiple)
+(defun bibtex-actions-org-cite-insert (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
   (let ((references (bibtex-actions-read)))
     (if multiple

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -607,23 +607,25 @@ interactively when `bibtex-actions-at-point-fallback' is non-nil.
 With prefix ARG, rebuild the cache before offering candidates."
   (interactive "P")
   (if (fboundp 'embark-dwim)
-      (let ((embark-keymap-alist '((bibtex . bibtex-actions-map)
-                                   (citation-key . bibtex-actions-buffer-map))))
-        (condition-case err
-            (let ((embark-target-finders '(bibtex-actions-citation-key-at-point)))
-              (if bibtex-actions-embark-dwim
-                    (embark-dwim)
-                  (embark-act)))
-          (user-error
-           (when (and (string-equal (error-message-string err) "No target found")
-                      bibtex-actions-at-point-fallback)
-             (bibtex-actions-run-default-action
-              (bibtex-actions-read :rebuild-cache arg))))))
+      (condition-case err
+          (if bibtex-actions-embark-dwim
+              (embark-dwim)
+            (embark-act))
+        (user-error
+         (when (and (string-equal (error-message-string err) "No target found")
+                    bibtex-actions-at-point-fallback)
+           (bibtex-actions-run-default-action
+            (bibtex-actions-read :rebuild-cache arg)))))
     (if-let ((keys (bibtex-actions-citation-key-at-point)))
         (funcall bibtex-actions-default-action keys)
       (when bibtex-actions-at-point-fallback
         (bibtex-actions-run-default-action
          (bibtex-actions-read :rebuild-cache arg))))))
+
+(with-eval-after-load "embark"
+  (add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
+  (add-to-list 'embark-keymap-alist '((bibtex . bibtex-actions-map)
+                                      (citation-key . bibtex-actions-buffer-map))))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -479,9 +479,9 @@ TEMPLATE."
 
 (when (require 'oc nil t)
   (org-cite-register-processor 'bibtex-actions
-    :insert (org-cite-make-insert-processor
-             (bibtex-actions-org-cite-insert t)
-             #'org-cite-basic--complete-style)
+    ;:insert (org-cite-make-insert-processor
+    ;         #'bibtex-actions-org-cite-insert
+    ;         #'org-cite-basic--complete-style)
     :follow (lambda (_datum _arg) (call-interactively 'bibtex-actions-at-point))))
 
 ;;; Embark

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -624,8 +624,8 @@ With prefix ARG, rebuild the cache before offering candidates."
 
 (with-eval-after-load "embark"
   (add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
-  (add-to-list 'embark-keymap-alist '((bibtex . bibtex-actions-map)
-                                      (citation-key . bibtex-actions-buffer-map))))
+  (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+  (add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-buffer-map)))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -183,18 +183,18 @@ If nil, prompt the user for an action through `embark-act'."
 
 (defvar bibtex-actions-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "t") 'bibtex-actions-add-pdf-attachment)
-    (define-key map (kbd "a") 'bibtex-actions-add-pdf-to-library)
-    (define-key map (kbd "b") 'bibtex-actions-insert-bibtex)
-    (define-key map (kbd "c") 'bibtex-actions-insert-citation)
-    (define-key map (kbd "k") 'bibtex-actions-insert-key)
-    (define-key map (kbd "f") 'bibtex-actions-insert-reference)
-    (define-key map (kbd "o") 'bibtex-actions-open)
-    (define-key map (kbd "e") 'bibtex-actions-open-entry)
-    (define-key map (kbd "l") 'bibtex-actions-open-link)
-    (define-key map (kbd "n") 'bibtex-actions-open-notes)
-    (define-key map (kbd "p") 'bibtex-actions-open-pdf)
-    (define-key map (kbd "r") 'bibtex-actions-refresh)
+    (define-key map "t" '("add pdf attachment" . bibtex-actions-add-pdf-attachment))
+    (define-key map "a" '("add pdf to library" . bibtex-actions-add-pdf-to-library))
+    (define-key map "b" '("insert bibtex" . bibtex-actions-insert-bibtex))
+    (define-key map "c" '("insert citation" . bibtex-actions-insert-citation))
+    (define-key map "k" '("insert key" . bibtex-actions-insert-key))
+    (define-key map "f" '("insert reference" . bibtex-actions-insert-reference))
+    (define-key map "o" '("open source" . bibtex-actions-open))
+    (define-key map "e" '("open reference entry" . bibtex-actions-open-entry))
+    (define-key map "l" '("open source link" . bibtex-actions-open-link))
+    (define-key map "n" '("open notes" . bibtex-actions-open-notes))
+    (define-key map "p" '("open source pdf" . bibtex-actions-open-pdf))
+    (define-key map "r" '("refresh references" . bibtex-actions-refresh))
     map)
   "Keymap for 'bibtex-actions'.")
 
@@ -493,21 +493,16 @@ TEMPLATE."
 
 (defvar bibtex-actions-buffer-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "t") 'bibtex-actions-add-pdf-attachment)
-    (define-key map (kbd "a") 'bibtex-actions-add-pdf-to-library)
-    (define-key map (kbd "o") 'bibtex-actions-open)
-    (define-key map (kbd "e") 'bibtex-actions-open-entry)
-    (define-key map (kbd "l") 'bibtex-actions-open-link)
-    (define-key map (kbd "n") 'bibtex-actions-open-notes)
-    (define-key map (kbd "p") 'bibtex-actions-open-pdf)
-    (define-key map (kbd "RET") 'bibtex-actions-run-default-action)
+    (define-key map "t" '("add pdf attachment" . bibtex-completion-add-PDF-attachment))
+    (define-key map "a" '("add pdf to library" . bibtex-completion-add-pdf-to-library))
+    (define-key map "o" '("open source" . bibtex-completion-open-any))
+    (define-key map "e" '("open reference entry" . bibtex-completion-show-entry))
+    (define-key map "l" '("open source link" . bibtex-completion-open-url-or-doi))
+    (define-key map "n" '("open notes" . bibtex-completion-edit-notes))
+    (define-key map "p" '("open source pdf" . bibtex-completion-open-pdf))
+    (define-key map "RET" '("default" . bibtex-actions-run-default-action))
     map)
-  "Keymap for Embark citation-key actions.
-
-This keymap is used by `bibtex-actions-at-point' internally.  It
-should not be added to `embark-keymap-alist' because interactive
-commands (i.e. bibtex-actions-*) currently do not work well with
-`embark-act' outside the minibuffer.")
+  "Keymap for Embark citation-key actions.")
 
 ;;; Command wrappers for bibtex-completion functions
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -597,7 +597,8 @@ With prefix, rebuild the cache before offering candidates."
 
 (defun bibtex-actions-run-default-action (keys)
   "Run the default action `bibtex-actions-default-action' on KEYS."
-  (funcall bibtex-actions-default-action keys))
+  (funcall bibtex-actions-default-action
+           (if (stringp keys) (split-string keys " & ") keys)))
 
 ;;;###autoload
 (defun bibtex-actions-at-point (&optional arg)

--- a/test/bibtex-actions.el
+++ b/test/bibtex-actions.el
@@ -21,7 +21,9 @@
 ;(advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
 
 ;; ensure that embark knows which map to use with bibtex entries
-;(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+(add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
+(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+(add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-buffer-map))
 
 (with-eval-after-load "org-cite"
   (setq org-cite-follow-processor 'bibtex-actions)
@@ -44,4 +46,3 @@
 
 ;; theme
 (load-theme 'modus-operandi t)
-

--- a/test/bibtex-actions.el
+++ b/test/bibtex-actions.el
@@ -14,18 +14,23 @@
 (require 'consult)
 
 ;; set binding for Embark context menu
-(global-set-key (kbd "M-o") #'embark-act)
+(global-set-key (kbd "M-;") #'embark-act)
+(global-set-key (kbd "M-.") #'embark-dwim)
 
 ;; replace CRM with consult alernative
 ;(advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
 
 ;; ensure that embark knows which map to use with bibtex entries
-(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+;(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+
+(with-eval-after-load "org-cite"
+  (setq org-cite-follow-processor 'bibtex-actions)
+  (setq org-cite-insert-processor 'bibtex-actions))
 
 ;; load the test bib file
 (setq bibtex-completion-bibliography "test.bib")
 
-(setq selectrum-fix-vertical-window-height 20)
+(setq vertico-count 20)
 
 ;; setup embark to use which-key
 (setq embark-action-indicator


### PR DESCRIPTION
This fixes the initial embark at-point integration.

With this PR, default behavior when point is on an `org-cite` citation or citation-reference:

- `M-x org-open-at-point` -> `embark-dwim` (the default action)
- `embark-act` presents bibtex-actions command options

Both `embark-act` and `embark-dwim` should also correctly work in `latex-mode`.

Please test and confirm this is all working as expected, including the minibuffer commands and `embark-act` behavior.

Also, I've updated the test script to show the `org-cite` capabilities.

Fix #164.