### PR TITLE
Add separate bibtex-actions-org-cite

### DIFF
--- a/README.org
+++ b/README.org
@@ -71,8 +71,8 @@ Bibtex-actions includes org-cite integration via a processor with "follow" and "
 To configure those, you can do:
 
 #+BEGIN_SRC emacs-lisp
-(setq org-cite-follow-processor 'bibtex-actions)
-(setq org-cite-insert-processor 'bibtex-actions)
+(setq org-cite-follow-processor 'bibtex-actions-org)
+(setq org-cite-insert-processor 'bibtex-actions-org)
 #+END_SRC
 
 The "insert processor" will use =bibtex-actions-read= to browse your library to insert and edit citations and citation references using the =org-cite-insert= command.

--- a/README.org
+++ b/README.org
@@ -67,13 +67,9 @@ The only thing, however, that you /must/ configure is where to find your bib fil
 
 *** Org-Cite
 
-Bibtex-actions includes org-cite integration via a processor with "follow" and "insert" capabilities.
-To configure those, you can do:
+Bibtex-actions includes org-cite integration in =bibtex-actions-org-cite=, which includes a processor with "follow" and "insert" capabilities.
 
-#+BEGIN_SRC emacs-lisp
-(setq org-cite-follow-processor 'bibtex-actions-org)
-(setq org-cite-insert-processor 'bibtex-actions-org)
-#+END_SRC
+To configure those, you can just load =bibtex-actions-org-cite=.
 
 The "insert processor" will use =bibtex-actions-read= to browse your library to insert and edit citations and citation references using the =org-cite-insert= command.
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -82,9 +82,10 @@
 (defvar bibtex-actions-org-cite-map
   (let ((map (make-sparse-keymap)))
     (define-key map "c" '("cite | insert/edit" . org-cite-insert))
-    (define-key map "o" '("cite | open-at-point" . org-open-at-point))
+    (define-key map "o" '("cite | open-at-point" . bibtex-actions-open))
     (define-key map "e" '("cite | open/edit entry" . bibtex-actions-open-entry))
     (define-key map "n" '("cite | open notes" . bibtex-actions-open-notes))
+    (define-key map "RET" '("cite | default action" . bibtex-actions-run-default-action))
     map)
   "Keymap for 'bibtex-actions-org-cite'.")
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -45,14 +45,6 @@
 (require 'oc-basic)
 (require 'embark)
 
-(declare-function bibtex-actions-at-point "bibtex-actions")
-(declare-function bibtex-actions-open "bibtex-actions")
-(declare-function bibtex-actions-open-pdf "bibtex-actions")
-(declare-function bibtex-actions-open-notes "bibtex-actions")
-(declare-function bibtex-actions-open-entry "bibtex-actions")
-(declare-function org-open-at-point "org")
-(declare-function org-cite-insert "org-cite")
-
 ;TODO
 ;(defvar bibtex-actions-org-cite-open-default
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -62,7 +62,7 @@
 
 (defun bibtex-actions-org-cite-follow (_datum _arg)
   "Follow processor for org-cite."
-  (call-interactively 'bibtex-actions-at-point))
+  (call-interactively 'embark-dwim))
 
 (org-cite-register-processor 'bibtex-actions-org-cite
   :insert (org-cite-make-insert-processor

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -79,10 +79,10 @@
 
 (defvar bibtex-actions-org-cite-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "c" '("(cite) insert/edit" . org-cite-insert))
-    (define-key map "o" '("(cite) open-at-point" . org-open-at-point))
-    (define-key map "e" '("(cite) open/edit entry" . bibtex-actions-open-entry))
-    (define-key map "n" '("(cite) open notes" . bibtex-actions-open-notes))
+    (define-key map "c" '("cite | insert/edit" . org-cite-insert))
+    (define-key map "o" '("cite | open-at-point" . org-open-at-point))
+    (define-key map "e" '("cite | open/edit entry" . bibtex-actions-open-entry))
+    (define-key map "n" '("cite | open notes" . bibtex-actions-open-notes))
     map)
   "Keymap for 'bibtex-actions-org-cite'.")
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -45,6 +45,9 @@
 (require 'oc-basic)
 (require 'embark)
 
+(declare-function bibtex-actions-at-point "bibtex-actions")
+(declare-function org-open-at-point "org")
+
 ;TODO
 ;(defvar bibtex-actions-org-cite-open-default
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -85,9 +85,9 @@
     (define-key map "o" '("cite | open-at-point" . bibtex-actions-open))
     (define-key map "e" '("cite | open/edit entry" . bibtex-actions-open-entry))
     (define-key map "n" '("cite | open notes" . bibtex-actions-open-notes))
-    (define-key map "RET" '("cite | default action" . bibtex-actions-run-default-action))
+    (define-key map (kbd "RET") '("cite | default action" . bibtex-actions-run-default-action))
     map)
-  "Keymap for 'bibtex-actions-org-cite'.")
+  "Keymap for 'bibtex-actions-org-cite' `embark' at-point functionality.")
 
 ;; Bibtex-actions-org-cite configuration
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -8,7 +8,7 @@
 ;; License: GPL-3.0-or-later
 ;; Version: 0.1
 ;; Homepage: https://github.com/bdarcus/bibtex-actions
-;; Package-Requires: ((emacs "26.3") (bibtex-actions "0.5"))
+;; Package-Requires: ((emacs "26.3"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -45,6 +45,11 @@
 (require 'oc-basic)
 (require 'embark)
 
+(declare-function bibtex-actions-at-point "bibtex-actions")
+(declare-function bibtex-actions-open "bibtex-actions")
+(declare-function bibtex-actions-open-pdf "bibtex-actions")
+(declare-function bibtex-actions-open-notes "bibtex-actions")
+(declare-function bibtex-actions-open-entry "bibtex-actions")
 (declare-function org-open-at-point "org")
 (declare-function org-cite-insert "org-cite")
 
@@ -60,7 +65,7 @@
         references
       (car references))))
 
-(defun bibtex-actions-org-cite-follow ()
+(defun bibtex-actions-org-cite-follow (_datum _arg)
   "Follow processor for org-cite."
   (call-interactively 'bibtex-actions-at-point))
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -70,6 +70,13 @@
            #'org-cite-basic--complete-style)
   :follow #'bibtex-actions-org-cite-follow)
 
+;;; Embark target finder
+
+(defun bibtex-actions-org-cite-citation-finder ()
+  "Return org-cite citation keys at point as a list for `embark'."
+  (when-let ((key (bibtex-actions-get-key-org-cite)))
+    (cons 'oc-citation-key (if (listp key) (string-join key " & ") key))))
+
 ;;; Keymap
 
 (defvar bibtex-actions-org-cite-map
@@ -88,9 +95,9 @@
 
 ;; Embark configuration for org-cite
 
-(add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
+(add-to-list 'embark-target-finders 'bibtex-actions-org-cite-citation-finder)
 (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
-(add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-org-cite-map))
+(add-to-list 'embark-keymap-alist '(oc-citation-key . bibtex-actions-org-cite-map))
 
 (provide 'bibtex-actions-org-cite)
 ;;; bibtex-actions-org-cite.el ends here

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -8,7 +8,7 @@
 ;; License: GPL-3.0-or-later
 ;; Version: 0.1
 ;; Homepage: https://github.com/bdarcus/bibtex-actions
-;; Package-Requires: ((emacs "26.3") (bibtex-actions "0.4"))
+;; Package-Requires: ((emacs "26.3") (bibtex-actions "0.5"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -74,10 +74,10 @@
 
 (defvar bibtex-actions-org-cite-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "c" '("(cite) insert/edit" . 'org-cite-insert))
-    (define-key map "o" '("(cite) open-at-point" . 'org-open-at-point))
-    (define-key map "e" '("(cite) open/edit entry" . 'bibtex-actions-open-entry))
-    (define-key map "n" '("(cite) open notes" . 'bibtex-actions-open-notes))
+    (define-key map "c" '("(cite) insert/edit" . org-cite-insert))
+    (define-key map "o" '("(cite) open-at-point" . org-open-at-point))
+    (define-key map "e" '("(cite) open/edit entry" . bibtex-actions-open-entry))
+    (define-key map "n" '("(cite) open notes" . bibtex-actions-open-notes))
     map)
   "Keymap for 'bibtex-actions-org-cite'.")
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -30,12 +30,7 @@
 ;;  This is a small package that intergrates bibtex-actions and org-cite.  It
 ;;  provides a simple org-cite processor with "follow" and "insert" capabilties.
 ;;
-;;  You can configure like so:
-;;
-;;  (setq org-cite-follow-processor 'bibtex-actions-org-cite)
-;;  (setq org-cite-insert-processor 'bibtex-actions-org-cite)
-;;
-;;  It also configures Embark integration with the above.
+;;  Simply load this file and it will configure them for 'org-cite.'
 ;;
 ;;; Code:
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -1,0 +1,96 @@
+;;; bibtex-actions-org-cite.el --- Org-cite support for bibtex-actions -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Bruce D'Arcus
+;;
+;; Author: Bruce D'Arcus <https://github.com/bdarcus>
+;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
+;; Created: July 11, 2021
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Homepage: https://github.com/bdarcus/bibtex-actions
+;; Package-Requires: ((emacs "26.3") (bibtex-actions "0.4"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  This is a small package that intergrates bibtex-actions and org-cite.  It
+;;  provides a simple org-cite processor with "follow" and "insert" capabilties.
+;;
+;;  You can configure like so:
+;;
+;;  (setq org-cite-follow-processor 'bibtex-actions-org-cite)
+;;  (setq org-cite-insert-processor 'bibtex-actions-org-cite)
+;;
+;;  It also configures Embark integration with the above.
+;;
+;;; Code:
+
+(require 'bibtex-actions)
+(require 'org)
+(require 'org-cite)
+(require 'oc-basic)
+(require 'embark)
+
+(declare-function org-open-at-point "org")
+(declare-function org-cite-insert "org-cite")
+
+;TODO
+;(defvar bibtex-actions-org-cite-open-default
+
+;; Org-cite processor
+
+(defun bibtex-actions-org-cite-insert (&optional multiple)
+  "Return a list of keys when MULTIPLE, or else a key string."
+  (let ((references (bibtex-actions-read)))
+    (if multiple
+        references
+      (car references))))
+
+(defun bibtex-actions-org-cite-follow ()
+  "Follow processor for org-cite."
+  (call-interactively 'bibtex-actions-at-point))
+
+(org-cite-register-processor 'bibtex-actions-org-cite
+  :insert (org-cite-make-insert-processor
+           #'bibtex-actions-org-cite-insert
+           #'org-cite-basic--complete-style)
+  :follow #'bibtex-actions-org-cite-follow)
+
+;;; Keymap
+
+(defvar bibtex-actions-org-cite-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "c" '("(cite) insert/edit" . 'org-cite-insert))
+    (define-key map "o" '("(cite) open-at-point" . 'org-open-at-point))
+    (define-key map "e" '("(cite) open/edit entry" . 'bibtex-actions-open-entry))
+    (define-key map "n" '("(cite) open notes" . 'bibtex-actions-open-notes))
+    map)
+  "Keymap for 'bibtex-actions-org-cite'.")
+
+;; Bibtex-actions-org-cite configuration
+
+(setq org-cite-follow-processor 'bibtex-actions-org-cite)
+(setq org-cite-insert-processor 'bibtex-actions-org-cite)
+
+;; Embark configuration for org-cite
+
+(add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
+(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+(add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-org-cite-map))
+
+(provide 'bibtex-actions-org-cite)
+;;; bibtex-actions-org-cite.el ends here

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -74,8 +74,8 @@
 
 (defun bibtex-actions-org-cite-citation-finder ()
   "Return org-cite citation keys at point as a list for `embark'."
-  (when-let ((key (bibtex-actions-get-key-org-cite)))
-    (cons 'oc-citation-key (if (listp key) (string-join key " & ") key))))
+  (when-let ((keys (bibtex-actions-get-key-org-cite)))
+    (cons 'oc-citation (bibtex-actions--stringify-keys keys))))
 
 ;;; Keymap
 
@@ -97,7 +97,7 @@
 
 (add-to-list 'embark-target-finders 'bibtex-actions-org-cite-citation-finder)
 (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
-(add-to-list 'embark-keymap-alist '(oc-citation-key . bibtex-actions-org-cite-map))
+(add-to-list 'embark-keymap-alist '(oc-citation . bibtex-actions-org-cite-map))
 
 (provide 'bibtex-actions-org-cite)
 ;;; bibtex-actions-org-cite.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -448,11 +448,15 @@ TEMPLATE."
 
 ;;; Embark
 
+(defun bibtex-actions--stringify-keys (keys)
+  "Return a list of KEYS as a crm-string for `embark'."
+  (if (listp keys) (string-join keys " & ") keys))
+
 (defun bibtex-actions-citation-key-at-point ()
   "Return citation keys at point as a list for `embark'."
-  (when-let ((key (or (bibtex-actions-get-key-org-cite)
+  (when-let ((keys (or (bibtex-actions-get-key-org-cite)
                       (bibtex-completion-key-at-point))))
-    (cons 'citation-key (if (listp key) (string-join key " & ") key))))
+    (cons 'citation-key (bibtex-actions--stringify-keys keys))))
 
 (defvar bibtex-actions-buffer-map
   (let ((map (make-sparse-keymap)))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -200,28 +200,7 @@ If nil, prompt the user for an action through `embark-act'."
 ;;; Org-cite citation function
 
 (defun bibtex-actions--format-citation-org (keys)
-  "Format org-cite citations for the entries in KEYS.
-
-The full citation syntax is:
-
-  [cite/style:common prefix ;prefix @key suffix; ... ; common suffix]
-
-Everything is optional, except the brackets, 'cite' and the colon.
-Also the citation must contain at least a key.
-So its minimal form is:
-
-  [cite:@key]
-
-Note that the prefix here is for the citation as a whole; if you
-need to add one specific to an individual citation item, you
-would need to add that after inserting.
-
-  [cite:see ;item prefix @key]
-
-The same is true for suffixes like page numbers, which are
-specific to the item, rather than the citation as a whole.
-
-  [cite: see ;@key pp23-24]"
+  "Format org-cite citations for the entries in KEYS."
   (let* ((prefix  (if bibtex-completion-cite-prompt-for-optional-arguments (read-from-minibuffer "Prefix: ") ""))
          (styles bibtex-actions-org-cite-styles)
          (style  (if bibtex-completion-cite-prompt-for-optional-arguments

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -477,12 +477,16 @@ TEMPLATE."
         references
       (car references))))
 
+(defun bibtex-actions-org-cite-follow ()
+  "Follow processor for org-cite."
+  (call-interactively 'bibtex-actions-at-point))
+
 (when (require 'oc nil t)
   (org-cite-register-processor 'bibtex-actions-org-cite
     :insert (org-cite-make-insert-processor
              #'bibtex-actions-org-cite-insert
              #'org-cite-basic--complete-style)
-    :follow (lambda (_datum _arg) (call-interactively 'bibtex-actions-at-point))))
+    :follow #'bibtex-actions-org-cite-follow))
 
 ;;; Embark
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -482,7 +482,7 @@ TEMPLATE."
   "Follow processor for org-cite."
   (call-interactively 'bibtex-actions-at-point))
 
-(when (require 'oc nil t)
+(with-eval-after-load "org-cite"
   (org-cite-register-processor 'bibtex-actions-org-cite
     :insert (org-cite-make-insert-processor
              #'bibtex-actions-org-cite-insert

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -478,10 +478,10 @@ TEMPLATE."
       (car references))))
 
 (when (require 'oc nil t)
-  (org-cite-register-processor 'bibtex-actions
-    ;:insert (org-cite-make-insert-processor
-    ;         #'bibtex-actions-org-cite-insert
-    ;         #'org-cite-basic--complete-style)
+  (org-cite-register-processor 'bibtex-actions-org-cite
+    :insert (org-cite-make-insert-processor
+             #'bibtex-actions-org-cite-insert
+             #'org-cite-basic--complete-style)
     :follow (lambda (_datum _arg) (call-interactively 'bibtex-actions-at-point))))
 
 ;;; Embark

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -472,6 +472,7 @@ TEMPLATE."
 
 (defun bibtex-actions-org-cite-insert (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
+  ;; FIX
   (let ((references (bibtex-actions-read)))
     (if multiple
         references

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -468,27 +468,6 @@ TEMPLATE."
       ('citation
        (org-cite-get-references elt t)))))
 
-;; Org-cite "follow" and "insert" processor
-
-(defun bibtex-actions-org-cite-insert (&optional multiple)
-  "Return a list of keys when MULTIPLE, or else a key string."
-  ;; FIX
-  (let ((references (bibtex-actions-read)))
-    (if multiple
-        references
-      (car references))))
-
-(defun bibtex-actions-org-cite-follow ()
-  "Follow processor for org-cite."
-  (call-interactively 'bibtex-actions-at-point))
-
-(with-eval-after-load "org-cite"
-  (org-cite-register-processor 'bibtex-actions-org-cite
-    :insert (org-cite-make-insert-processor
-             #'bibtex-actions-org-cite-insert
-             #'org-cite-basic--complete-style)
-    :follow #'bibtex-actions-org-cite-follow))
-
 ;;; Embark
 
 (defun bibtex-actions-citation-key-at-point ()

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -250,7 +250,7 @@ offering the selection candidates"
          (initial-input (assoc-default initial bibtex-actions-initial-inputs))
          (chosen
           (completing-read-multiple
-           "BibTeX entries: "
+           "References: "
            (lambda (string predicate action)
              (if (eq action 'metadata)
                  `(metadata

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -567,27 +567,11 @@ With prefix, rebuild the cache before offering candidates."
            (if (stringp keys) (split-string keys " & ") keys)))
 
 ;;;###autoload
-(defun bibtex-actions-at-point (&optional arg)
-  "Run the default action on citation keys found at point.
-If no citation key is found, target entries can be chosen
-interactively when `bibtex-actions-at-point-fallback' is non-nil.
-With prefix ARG, rebuild the cache before offering candidates."
-  (interactive "P")
-  (if (fboundp 'embark-dwim)
-      (condition-case err
-          (if bibtex-actions-embark-dwim
-              (embark-dwim)
-            (embark-act))
-        (user-error
-         (when (and (string-equal (error-message-string err) "No target found")
-                    bibtex-actions-at-point-fallback)
-           (bibtex-actions-run-default-action
-            (bibtex-actions-read :rebuild-cache arg)))))
+(defun bibtex-actions-dwim ()
+  "Run the default action on citation keys found at point."
+  (interactive)
     (if-let ((keys (bibtex-actions-citation-key-at-point)))
-        (funcall bibtex-actions-default-action keys)
-      (when bibtex-actions-at-point-fallback
-        (bibtex-actions-run-default-action
-         (bibtex-actions-read :rebuild-cache arg))))))
+        (funcall bibtex-actions-default-action keys)))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -607,10 +607,5 @@ With prefix ARG, rebuild the cache before offering candidates."
         (bibtex-actions-run-default-action
          (bibtex-actions-read :rebuild-cache arg))))))
 
-(with-eval-after-load "embark"
-  (add-to-list 'embark-target-finders 'bibtex-actions-citation-key-at-point)
-  (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
-  (add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-buffer-map)))
-
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -178,7 +178,6 @@ If nil, prompt the user for an action through `embark-act'."
   :group 'bibtex-actions
   :type '(repeat string))
 
-
 ;;; Keymap
 
 (defvar bibtex-actions-map

--- a/test/bibtex-actions.el
+++ b/test/bibtex-actions.el
@@ -10,9 +10,9 @@
 ;; activate additional packages we need, including bibtex-actions
 (require 'embark)
 (require 'bibtex-actions)
+(require 'bibtex-actions-org-cite)
 (require 'which-key)
 (require 'consult)
-
 ;; set binding for Embark context menu
 (global-set-key (kbd "M-;") #'embark-act)
 (global-set-key (kbd "M-.") #'embark-dwim)

--- a/test/bibtex-actions.el
+++ b/test/bibtex-actions.el
@@ -26,8 +26,8 @@
 (add-to-list 'embark-keymap-alist '(citation-key . bibtex-actions-buffer-map))
 
 (with-eval-after-load "org-cite"
-  (setq org-cite-follow-processor 'bibtex-actions)
-  (setq org-cite-insert-processor 'bibtex-actions))
+  (setq org-cite-follow-processor 'bibtex-actions-org-cite)
+  (setq org-cite-insert-processor 'bibtex-actions-org-cite))
 
 ;; load the test bib file
 (setq bibtex-completion-bibliography "test.bib")

--- a/test/install.el
+++ b/test/install.el
@@ -31,7 +31,7 @@
 (package-install 'bibtex-completion)
 ;; we load this locally, to facilitate development testing on branches
 (load-relative "../bibtex-actions.el")
-
+(load-relative "../bibtex-actions-org-cite.el")
 ;; theme that supports selectrum and vertico
 (package-install 'modus-themes)
 


### PR DESCRIPTION
## please review/test

### Summary

I've decided to move org-cite specific stuff into a separate `bibtex-actions-org-cite`. We can start with this, and expand it as needed, including possibly later considering a minor mode and such.

It reflects where I ended up, where I was finding it difficult to fix the problem with the insert processor that @ilupin [discovered](https://github.com/bdarcus/bibtex-actions/pull/171#issuecomment-877738027), and it seemed easier to split out the org-cite stuff into a separate `bibtex-actions-org-cite` file, and remove the `with-eval-after-load` embark config from the main file.

I think this is the right approach, but could use some more review and testing.

You should just be able to load the file and it will work with `org-cite` (assuming you have that properly setup).

### Menu experiments

Note also I am experimenting here with the menu descriptions. 

So here I'm using a mix of `bibtex-actions` and native `org` commands (though where we are plugging in `bibtex-actions` commands anyway), but hidden behind descriptions with a common "cite" context prefix.

![Screenshot from 2021-07-12 15-10-12](https://user-images.githubusercontent.com/1134/125342989-8b939e80-e323-11eb-987d-30a374d92aec.png)

I'd actually like to also remove the embark map here,  and the other menu items, so it's just a very clean menu, focused only on the contextual commands.

### Other issues

I still need to:

- get the requires statements on the file correct; not sure on that
- I'm also looking for suggestions on how to modify the `use-package` example on the README to use this