### PR TITLE
oc: Use bibtex-actions-at-point-function for follow processor

### DIFF
--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -36,7 +36,7 @@
 
 (require 'bibtex-actions)
 (require 'org)
-(require 'org-cite)
+(require 'oc)
 (require 'oc-basic)
 (require 'embark)
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -57,7 +57,7 @@
 
 (defun bibtex-actions-org-cite-follow (_datum _arg)
   "Follow processor for org-cite."
-  (call-interactively 'embark-dwim))
+  (call-interactively 'bibtex-actions-at-point-function))
 
 (org-cite-register-processor 'bibtex-actions-org-cite
   :insert (org-cite-make-insert-processor
@@ -88,6 +88,7 @@
 
 (setq org-cite-follow-processor 'bibtex-actions-org-cite)
 (setq org-cite-insert-processor 'bibtex-actions-org-cite)
+(setq bibtex-actions-at-point-function 'embark-dwim)
 
 ;; Embark configuration for org-cite
 

--- a/bibtex-actions-org-cite.el
+++ b/bibtex-actions-org-cite.el
@@ -57,7 +57,7 @@
 
 (defun bibtex-actions-org-cite-follow (_datum _arg)
   "Follow processor for org-cite."
-  (call-interactively 'bibtex-actions-at-point-function))
+  (call-interactively bibtex-actions-at-point-function))
 
 (org-cite-register-processor 'bibtex-actions-org-cite
   :insert (org-cite-make-insert-processor

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -161,12 +161,10 @@ means no action."
   :type '(choice (const :tag "Prompt" 'prompt)
                  (const :tag "Ignore" nil)))
 
-(defcustom bibtex-actions-embark-dwim t
-  "Whether to run the default action on citation keys at point.
-If non-nil, call the default embark action through `embark-dwim'.
-If nil, prompt the user for an action through `embark-act'."
+(defcustom bibtex-actions-at-point-function 'embark-dwim
+  "The function to run for 'bibtex-actions-at-point'."
   :group 'bibtex-actions
-  :type 'boolean)
+  :type 'function)
 
 ;;; History, including future history list.
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -569,8 +569,8 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-dwim ()
   "Run the default action on citation keys found at point."
   (interactive)
-    (if-let ((keys (bibtex-actions-citation-key-at-point)))
-        (funcall bibtex-actions-default-action keys)))
+  (if-let ((keys (bibtex-actions-citation-key-at-point)))
+      (funcall bibtex-actions-default-action keys)))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -161,7 +161,7 @@ means no action."
   :type '(choice (const :tag "Prompt" 'prompt)
                  (const :tag "Ignore" nil)))
 
-(defcustom bibtex-actions-at-point-function 'embark-dwim
+(defcustom bibtex-actions-at-point-function 'bibtex-actions-dwim
   "The function to run for 'bibtex-actions-at-point'."
   :group 'bibtex-actions
   :type 'function)


### PR DESCRIPTION
This is @minad's suggestion: https://github.com/bdarcus/bibtex-actions/pull/171#discussion_r667755127

Edit: actually, I integrated a part of that suggestion in #174. This just refines it.