### PR TITLE
Add transient menu as default at-point

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -483,7 +483,9 @@ TEMPLATE."
   "Return citation keys at point as a list for `embark'."
   (when-let ((keys (or (bibtex-actions-get-key-org-cite)
                       (bibtex-completion-key-at-point))))
-    (cons 'citation-key (bibtex-actions--stringify-keys keys))))
+    (if (= bibtex-actions-default-action 'embark-act)
+        (cons 'citation-key (bibtex-actions--stringify-keys keys))
+      keys)))
 
 
 ;;; Command wrappers for bibtex-completion functions
@@ -579,7 +581,9 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-run-default-action (keys)
   "Run the default action `bibtex-actions-default-action' on KEYS."
   (funcall bibtex-actions-default-action
-           (if (stringp keys) (split-string keys " & ") keys)))
+           (if (or (= bibtex-actions-default-action 'embark-act)
+                   (stringp keys))
+               (split-string keys " & ") keys)))
 
 ;;;###autoload
 (defun bibtex-actions-dwim ()

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -38,6 +38,7 @@
 ;;; Code:
 
 (require 'bibtex-completion)
+(require 'transient)
 
 (declare-function org-element-context "org-element")
 (declare-function org-element-property "org-element")
@@ -161,7 +162,7 @@ means no action."
   :type '(choice (const :tag "Prompt" 'prompt)
                  (const :tag "Ignore" nil)))
 
-(defcustom bibtex-actions-at-point-function 'bibtex-actions-dwim
+(defcustom bibtex-actions-at-point-function 'bibtex-actions-transient-menu
   "The function to run for 'bibtex-actions-at-point'."
   :group 'bibtex-actions
   :type 'function)
@@ -209,6 +210,18 @@ means no action."
     (define-key map (kbd "RET") '("cite| default action" . bibtex-actions-run-default-action))
     map)
   "Keymap for Embark citation-key actions.")
+
+(transient-define-prefix bibtex-actions-transient-menu ()
+  "Transient menu for bibtex-actions."
+  ["Reference(s)\n"
+   ["Open"
+    ("p" "PDF" bibtex-actions-open-pdf)
+    ("b" "BibTEX" bibtex-actions-open-entry)
+    ("l" "URL" bibtex-actions-open-link)
+    ("n" "Notes" bibtex-actions-open-notes)]
+
+   ["Library"
+    ("r" "Refresh" bibtex-actions-refresh)]])
 
 ;;; Org-cite citation function
 


### PR DESCRIPTION
![Screenshot from 2021-07-23 07-43-10](https://user-images.githubusercontent.com/1134/126777132-86bd5e45-992e-4dbe-91c1-a17416b82171.png)

I've been wanting to get embark which-key menus to do something like this, but it's not really designed to.

Edit: I have decided to remove mention of `which-key` in the repo, though I still need to update screenshots.

So this proposes to add a `transient.el` map, and have that the default at-point command, across the different configuration types, including with org-cite.

It has the advantage that it will work with a plain installation, without Embark, but is also probably better even with it.

Doesn't currently work, though; getting this error, which is probably because current code is designed around Embark:

```console
concat: Wrong type argument: stringp, citation-key
```

If I add a check for embark before stringifying the keys, I get farther, but this error:

```console
bibtex-actions-dwim: Wrong type argument: number-or-marker-p, bibtex-actions-open
```

If I look in debugger, seems close, but odd about the nil here:

```console
 funcall-interactively(bibtex-actions-open-link (nil "berlet2000"))
```

WDYT @ilupin - is there an easy fix to allow this?

Is yes, can build on it; the final menu will be more complete, and we can expand the available actions over time.
