### PR TITLE
support local bibs

### DIFF
--- a/README.org
+++ b/README.org
@@ -222,61 +222,26 @@ You then have two ways to access these strings from the completion prompt:
 =Bibtex-actions= also preserves the history of your selections (see caveat below about multiple candidate selection though), which are also accessible in your completion UI, but by using =M-p=.
 You can save this history across sessions by adding =bibtex-actions-history= to =savehist-additional-variables=.
 
-** Pre-filtering entries
-    :PROPERTIES:
-    :CUSTOM_ID: prefiltering-entries
-    :END:
-
-By default, =bibtex-actions= will, assuming you are using =orderless= or =prescient= to filter candidates, pre-filter entries for the following commands.
-
-1. =bibtex-actions-open=: pre-narrows the list to those which have associated pdf or links
-2. =bibtex-actions-open-link=: pre-narrows the list to those which have associated links
-3. =bibtex-actions-open-pdf=: -pre-narrows the list to those which have associated pdf(s)
-
-That is, upon running the command, an =initial-input= value will be inserted to narrow the results. 
-You can also delete that if you prefer to see the full list of candidates.
-
-By default, pre-filtering of =bibtex-actions-open-notes= is off, because the command by default will create a new note if none is available, and therefore it makes sense to have access to your full library. 
-But you can customize this to pre-filter if you prefer.
-
-If you want to modify those values, or remove them entirely, you can set =bibtex-actions-initial-inputs= like so; in this case turning off pre-filtering for =bibtex-actions-open-pdf=:
-
-#+begin_src elisp
-(setq bibtex-actions-initial-inputs
-  '((pdf    . nil)
-    (note   . nil)
-    (link   . "has:link")
-    (source . "has:link\\|has:pdf"))
-#+end_src
-
 ** Refreshing the library display
     :PROPERTIES:
     :CUSTOM_ID: refreshing-the-library-display
     :END:
 
-Bibtex-actions uses a cache to speed up library display.
+=Bibtex-actions= uses two caches to speed up library display; one for the global bibliography, and another for local files specific to a buffer.
 This is great for performance, but means the data can become stale if you modify it.
 
-The =bibtex-actions-refresh= command will reload the cache, and you can call this manually. 
+The =bibtex-actions-refresh= command will reload the caches, and you can call this manually.
 You can also call any of the =bibtex-actions= commands with a prefix argument: =C-u M-x bibtex-actions-insert-key=.
 
-Finally, another option is to add =bibtex-completion=-style proactive loading externally by using =filenotify= something like this:
+Another option is to add a hook, something like this:
 
 #+BEGIN_SRC emacs-lisp
-  ;; Of course, you could also use `bibtex-completion-bibliography` here, but would need 
-  ;; to adapt this if you specify multiple files.
-  (file-notify-add-watch 
-    "/path/to/file.bib" '(change) 'bibtex-actions-refresh)
-#+END_SRC
+(defun gen-bib-cache-idle ()
+  "Generate bib item caches with idle timer"
+  (run-with-idle-timer 0.5 nil #'bibtex-actions-refresh))
 
-You can also extend this to do the same thing for your PDF files, or notes:
-
-#+BEGIN_SRC emacs-lisp
-  (file-notify-add-watch 
-    bibtex-completion-library-path '(change) 'bibtex-actions-refresh)
-
-  (file-notify-add-watch 
-    bibtex-completion-note-path '(change) 'bibtex-actions-refresh)
+(add-hook 'LaTeX-mode-hook #'gen-bib-cache-idle)
+(add-hook 'org-mode-hook #'gen-bib-cache-idle)
 #+END_SRC
 
 For additional configuration options on this, see [[https://github.com/bdarcus/bibtex-actions/wiki/Configuration#automating-path-watches][the wiki]].

--- a/README.org
+++ b/README.org
@@ -233,7 +233,7 @@ This is great for performance, but means the data can become stale if you modify
 The =bibtex-actions-refresh= command will reload the caches, and you can call this manually.
 You can also call any of the =bibtex-actions= commands with a prefix argument: =C-u M-x bibtex-actions-insert-key=.
 
-Another option is to add a hook, something like this:
+Another option to make the completion interface more seamless is to add a hook which generates the cache after a buffer is opened. This can be done when emacs has been idle (half a second in the example below) with something like this:
 
 #+BEGIN_SRC emacs-lisp
 (defun gen-bib-cache-idle ()

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -293,10 +293,10 @@ key associated with each one."
                     (s-join bibtex-actions-symbol-separator
                             (list pdf note link))"	") suffix))))
 
-(defvar bibtex-actions--candidates-cache nil
+(defvar bibtex-actions--candidates-cache 'uninitialized
   "Store the global candidates list.")
 
-(defvar-local bibtex-actions--local-candidates-cache nil
+(defvar-local bibtex-actions--local-candidates-cache 'uninitialized
   ;; We use defvar-local so can maintain per-buffer candidate caches.
   "Store the local (per-buffer) candidates list.")
 
@@ -305,12 +305,12 @@ key associated with each one."
 If the cache is nil, this will load the cache.
 If FORCE-REBUILD-CACHE is t, force reloading the cache."
   (when (or force-rebuild-cache
-            (not bibtex-actions--candidates-cache)
-            (not bibtex-actions--local-candidates-cache))
+            (eq 'uninitialized bibtex-actions--candidates-cache)
+            (eq 'uninitialized bibtex-actions--local-candidates-cache))
     (bibtex-actions-refresh force-rebuild-cache))
   (seq-concatenate 'list
-                   ((lambda (x) (if (eq x t) nil x)) bibtex-actions--local-candidates-cache)
-                   ((lambda (x) (if (eq x t) nil x)) bibtex-actions--candidates-cache)))
+                   bibtex-actions--local-candidates-cache
+                   bibtex-actions--candidates-cache))
 
 ;;;###autoload
 (defun bibtex-actions-refresh (&optional force-rebuild-cache)
@@ -324,10 +324,10 @@ is non-nil, also run the `bibtex-actions-before-refresh-hook' hook."
   ;; itself is used to indicate a cache that hasn't been computed this is to
   ;; work around the fact that we can't differentiate between empty list and nil
   (setq bibtex-actions--candidates-cache
-        ((lambda (x) (if x x t)) (bibtex-actions--format-candidates)))
+        (bibtex-actions--format-candidates))
   (let ((bibtex-completion-bibliography (bibtex-actions--local-files-to-cache)))
     (setq bibtex-actions--local-candidates-cache
-        ((lambda (x) (if x x t)) (bibtex-actions--format-candidates "is:local")))))
+        (bibtex-actions--format-candidates "is:local"))))
 
 ;;;###autoload
 (defun bibtex-actions-insert-preset ()


### PR DESCRIPTION
This adds support for local bib files, by adding a buffer-local cache.

When visiting a buffer, you should get the correct mix of local and global bib files loaded automatically.

Also adds a hidden `is:local` string to local candidates, so that you can filter local items like so:

![image](https://user-images.githubusercontent.com/1134/128362123-ce358d09-9e9c-485b-b714-aae21daf3008.png)

Open questions:

1. Should local candidates already included in the global cache be removed from the local cache?
2. ~Best options for auto-freshing of cache so users don't have to think about this? Maybe we include an [example auto-timer hook](https://github.com/bdarcus/bibtex-actions/pull/208#issuecomment-892589239) in the README?~ settled; working on this
3. Should there be some kind of UI hint for local candidates, building on the above filtering? We discuss below grouping as one option, but there are more subtle alternatives. Think, for example, how presence of related PDFs or notes is currently indicated in the affixation prefix (though if we go this way, we need a good default symbol). For example:

![image](https://user-images.githubusercontent.com/1134/128396282-a63503bb-ad86-492e-aada-93e4428b2430.png)

... or, different symbol:

![image](https://user-images.githubusercontent.com/1134/128400927-3e92ba9e-d00d-408b-9f81-920ac9cffdb0.png)

Fix #150.