### PR TITLE
Fix embark-act > RET

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -530,8 +530,8 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-dwim ()
   "Run the default action on citation keys found at point."
   (interactive)
-  (if-let ((keys (bibtex-actions-citation-key-at-point)))
-      (funcall bibtex-actions-default-action keys)))
+  (if-let ((keys (cdr (bibtex-actions-citation-key-at-point))))
+      (bibtex-actions-run-default-action keys)))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -522,7 +522,9 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-run-default-action (keys)
   "Run the default action `bibtex-actions-default-action' on KEYS."
   (funcall bibtex-actions-default-action
-           (if (stringp keys) (split-string keys " & ") keys)))
+           (if (stringp keys)
+               (split-string keys " & ")
+             (split-string (cdr keys) " & "))))
 
 ;;;###autoload
 (defun bibtex-actions-dwim ()

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -238,14 +238,12 @@ strings by style."
 
 (defvar oc-bibtex-actions-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "c" '("edit citation" . org-cite-insert))
-    (define-key map (kbd "o") '("open source document" . bibtex-actions-open))
+    (define-key map (kbd "o") '("open source (file or link)" . bibtex-actions-open))
     (define-key map (kbd "e") '("open bibtex entry" . bibtex-actions-open-entry))
-    (define-key map (kbd "l") '("open source URL or DOI" . bibtex-actions-open-link))
+    (define-key map (kbd "f") '("open source file" . bibtex-actions-open-pdf))
+    (define-key map (kbd "l") '("open source link" . bibtex-actions-open-link))
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
-    (define-key map (kbd "p") '("open PDF" . bibtex-actions-open-pdf))
     (define-key map (kbd "r") '("refresh library" . bibtex-actions-refresh))
-    (define-key map (kbd "RET") '("default action" . bibtex-actions-dwim))
     map)
   "Keymap for 'oc-bibtex-actions' `embark' at-point functionality.")
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -245,7 +245,7 @@ strings by style."
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "p") '("open PDF" . bibtex-actions-open-pdf))
     (define-key map (kbd "r") '("refresh library" . bibtex-actions-refresh))
-    (define-key map (kbd "RET") '("default action" . bibtex-actions-run-default-action))
+    (define-key map (kbd "RET") '("default action" . bibtex-actions-dwim))
     map)
   "Keymap for 'oc-bibtex-actions' `embark' at-point functionality.")
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -250,7 +250,7 @@ strings by style."
 ;; Embark configuration for org-cite
 
 (add-to-list 'embark-target-finders 'oc-bibtex-actions-citation-finder)
-(add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map))
+(add-to-list 'embark-keymap-alist '(bibtex . oc-bibtex-actions-map))
 (add-to-list 'embark-keymap-alist '(oc-citation . oc-bibtex-actions-map))
 (when (boundp 'embark-pre-action-hooks)
   ;; Ensure that Embark ignores the target for 'org-cite-insert'.


### PR DESCRIPTION
This is a minimal alternative to #199.

The following works in org-cite:

- `M-x bibtex-actions-dwim`
- `M-x embark-dwim`
- `M-x org-open-at-point`

The only thing that doesn't work (for me at least):

- `embark-act` -> `RET` 

I do now get this message when clicking on a key, though, which might be a hint:

```console
Embark: The action indicator takes three arguments, KEYMAP, TARGET and TYPE.
```

If we can't get this working, I'll just remove that binding, which isn't that useful anyway.

Fix #195.

cc @ilupin 