### PR TITLE
Generate style list dynamically

### DIFF
--- a/README.org
+++ b/README.org
@@ -309,6 +309,18 @@ The "insert processor" will use =bibtex-actions-read= to browse your library to 
 The "follow processor" provides at-point functionality accessible via the =org-open-at-point= command.
 By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you invoke =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.
 
+Org-cite citations include optional "styles" and "variants" to locally modify the citation rendering.
+To edit these, just make sure point is on the citation prefix before running =org-cite-insert=, and you will get a list of available styles.
+That list is based on your configuration; if you have the =oc-natbib= and =oc-csl= processors configured, for example, the list will include the styles and variants available in those two processors.
+The variants included in the bundled processors include the following, with the shortcuts in parentheses:
+
+- =bare= (=b=): without surrounding punctuation
+- =caps= (=c=): force initial capitalization
+- =full= (=f=): ignore et al shortening for author names
+
+Generally, you shouldn't need these, but they can be useful in certain circumstances.
+If an export processor doesn't support a specific variant for a specific style, it should just fallback to the base style.
+For example, if you specify =text/f=, and the export processor you use doesn't support the =f= variant there, it should just output as if you specified =text=.
 
 *** =M-x=
     :PROPERTIES:

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -202,18 +202,18 @@ With PROC list, limits to specific processors."
   (call-interactively bibtex-actions-at-point-function))
 
 (defun oc-bibtex-actions-select-style ()
-"Complete a citation style for org-cite with preview."
+  "Complete a citation style for org-cite with preview."
   (interactive)
-  (let* ((oc-styles (oc-bibtex-actions--styles-candidates))
+  (let* ((oc-styles
+          ;; Sort the list upfront, but let completion UI handle beyond that.
+          (sort (oc-bibtex-actions--flat-supported-styles) 'string-lessp))
          (style
           (completing-read
            "Styles: "
            (lambda (str pred action)
              (if (eq action 'metadata)
                  `(metadata
-                   (annotation-function . oc-bibtex-actions--style-preview-annote)
-                   (cycle-sort-function . identity)
-                   (display-sort-function . identity)
+                   ;(annotation-function . oc-bibtex-actions--style-preview-annote)
                    (group-function . oc-bibtex-actions--styles-group-fn))
                (complete-with-action action oc-styles str pred)))))
          (style-final (string-trim style)))
@@ -223,7 +223,7 @@ With PROC list, limits to specific processors."
   "Generate candidate list."
   ;; TODO extract the style+variant strings from 'org-cite-support-styles'.
   (cl-loop for style in
-           (cdr (assoc oc-bibtex-actions-preview-target
+           (cdr (assoc oc-bibtex-actions-style-targets
                         oc-bibtex-actions-style-preview-alist))
            collect (cons
                     (concat "  " (truncate-string-to-width (car style) 20 nil 32)) (cdr style))))
@@ -246,6 +246,7 @@ strings by style."
        ((string= short-style "locators") "Locators-Only")
        ((string= short-style "text") "Textual/Narrative")
        ((string= short-style "nocite") "No Cite")
+       ((string= short-style "year") "Year-Only")
        ((string= short-style "noauthor") "Suppress Author")))))
 
 (defun oc-bibtex-actions-csl-render-citation (citation)

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -52,14 +52,19 @@
   "Face for org-cite previews."
   :group 'oc-bibtex-actions)
 
-(defcustom oc-bibtex-actions-preview-target 'csl
-  "Export processor target for which to display previews."
-  ;; REVIEW not sure this is the best approach.
+(defcustom oc-bibtex-actions-styles-format 'long
+  "Style format; whether to use full style names or shortcuts."
   :group 'oc-bibtex-actions
   :type '(choice
-          (const biblatex)
-          (const csl)
-          (const natbib)))
+          (const long)
+          (const short)))
+
+(defcustom oc-bibtex-actions-style-targets nil
+  "Export processor targets to include in styles list.
+
+If nil, use 'org-cite-supported-styles'."
+  :group 'oc-bibtex-actions
+  :type '(repeat :tag "org-cite export processor" symbol))
 
 ;;; Internal variables
 
@@ -159,6 +164,27 @@
 
 ;TODO
 ;(defvar oc-bibtex-actions-open-default
+
+(defun oc-bibtex-actions--flat-supported-styles (&optional proc)
+  "Return a flat list of supported styles.
+
+This converts 'org-cite-supported-styles' to a flat list for use
+as completion candidates.
+
+With PROC list, limits to specific processors."
+  (let ((styles (list)))
+    (cl-loop for s in
+             (org-cite-supported-styles
+              (or proc oc-bibtex-actions-style-targets)) do
+             (let* ((style-name
+                     (if (eq 'long oc-bibtex-actions-styles-format)
+                         (caar s)(cadar s)))
+                    (style
+                     (if (string= "nil" style-name) "" style-name)))
+               (push (if (string= "" style) "/" style) styles)
+               (cl-loop for v in (cdr s) do
+                        (push (concat style "/" (cadr v)) styles))))
+    styles))
 
 ;;; Org-cite processors
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -181,7 +181,11 @@ With PROC list, limits to specific processors."
                          (caar s)(cadar s)))
                     (style
                      (if (string= "nil" style-name) "" style-name)))
-               (push (if (string= "" style) "/" style) styles)
+               (push
+                ;; Highlight the styles without variant.
+                (propertize
+                 (if (string= "" style) "/" style) 'face 'bibtex-actions-highlight)
+                styles)
                (cl-loop for v in (cdr s) do
                         (push (concat style "/" (cadr v)) styles))))
     styles))


### PR DESCRIPTION
Generate style candidates via `org-cite-supported-styles`, and for the
time being, comments out the annotation-function.

Also:

- add section on styles to the README
- removing sorting on group-function