### PR TITLE
bibtex-actions--process-display-formats refactor + filenotify improvements

### DIFF
--- a/bibtex-actions-utils.el
+++ b/bibtex-actions-utils.el
@@ -114,8 +114,13 @@ If it is other than 'global or 'local invalidate both"
 
 CHANGE refers to the notify argument."
   (cl-case (cadr change)
-    ((nil changed) (message (symbol-name (cadr change))) (funcall func scope))
-    ((created deleted renamed) (bibtex-actions-filenotify-refresh scope))))
+    ((nil changed) (funcall func scope))
+    ((created deleted renamed) (if (member (nth 2 change)
+                                           (seq-concatenate 'list
+                                                            bibtex-actions-bibliography
+                                                            (bibtex-actions--local-files-to-cache)))
+                                   (bibtex-actions-filenotify-refresh scope)
+                                 (funcall func scope)))))
 
 (defun bibtex-actions--filenotify-callback (scope &optional change)
   "A by SCOPE callback according to `bibtex-actions-filenotify-callback'.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -433,11 +433,10 @@ If the cache is unintialized, this will load the cache.
 If FORCE-REBUILD-CACHE is t, force reload the cache."
   (if force-rebuild-cache
       (bibtex-actions-refresh force-rebuild-cache)
-    (progn
       (when (eq 'uninitialized bibtex-actions--candidates-cache)
         (bibtex-actions-refresh nil 'global))
       (when (eq 'uninitialized bibtex-actions--local-candidates-cache)
-        (bibtex-actions-refresh nil 'local))))
+        (bibtex-actions-refresh nil 'local)))
   (seq-concatenate 'list
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -435,9 +435,9 @@ If FORCE-REBUILD-CACHE is t, force reload the cache."
       (bibtex-actions-refresh force-rebuild-cache)
     (progn
       (when (eq 'uninitialized bibtex-actions--candidates-cache)
-        (bibtex-actions-refresh nil 'local))
+        (bibtex-actions-refresh nil 'global))
       (when (eq 'uninitialized bibtex-actions--local-candidates-cache)
-        (bibtex-actions-refresh nil 'global))))
+        (bibtex-actions-refresh nil 'local))))
   (seq-concatenate 'list
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -343,12 +343,8 @@ personal names of the form 'family, given'."
   "Format candidates from FILES, with optional hidden CONTEXT metadata.
 This both propertizes the candidates for display, and grabs the
 key associated with each one."
-  (let* ((main-template
-         (bibtex-actions--process-display-formats
-          bibtex-actions-template))
-         (suffix-template
-          (bibtex-actions--process-display-formats
-           bibtex-actions-template-suffix))
+  (let* ((main-template bibtex-actions-template)
+         (suffix-template bibtex-actions-template-suffix)
          (main-width (truncate (* (frame-width) 0.65)))
          (suffix-width (truncate (* (frame-width) 0.34))))
     (cl-loop for candidate being the hash-values of (parsebib-parse files)
@@ -502,7 +498,7 @@ TEMPLATE."
             (bibtex-actions-get-value "=type=" entry) template 'case-fold)
            ;; Otherwise, use the generic template.
            (assoc t template)))
-         (format-string (cadr format)))
+         (format-string (cdr format)))
     (s-format
      format-string
      (lambda (raw-field)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -483,19 +483,10 @@ are refreshed."
    for format in formats
    collect
    (let* ((format-string (cdr format))
-          (fields-width 0)
-          (string-width
-           (string-width
-            (s-format
-             format-string
-             (lambda (field)
-               (setq fields-width
-                     (+ fields-width
-                        (string-to-number
-                         (or (cadr (split-string field ":"))
-                             ""))))
-               "")))))
-     (cons (car format) (cons format-string (+ fields-width string-width))))))
+          (total-width (apply #'+
+                              (seq-map #'string-to-number
+                                       (split-string format-string ":")))))
+     (cons (car format) (cons format-string total-width)))))
 
 (defun bibtex-actions--format-entry (entry width template)
   "Formats a BibTeX ENTRY for display in results list.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -522,14 +522,14 @@ TEMPLATE."
                                  field-width
                                width))
               ;; Make sure we always return a string, even if empty.
-              (field-value (bibtex-completion-clean-string
-                            (or (bibtex-actions--field-value-for-formatting field-name entry)
-                                " "))))
+              (field-value (or (bibtex-actions--field-value-for-formatting field-name entry)
+                               " ")))
          (truncate-string-to-width field-value display-width 0 ?\s))))))
 
 (defun bibtex-actions--field-value-for-formatting (field-name entry)
   "Field formatting for ENTRY FIELD-NAME."
-  (let ((field-value (bibtex-actions-get-value field-name entry)))
+  (let ((field-value (bibtex-completion-clean-string
+                      (bibtex-actions-get-value field-name entry))))
     (pcase field-name
       ("author" (if field-value
                     (bibtex-actions-shorten-names field-value)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -431,10 +431,13 @@ has not yet been created")
   "Get the cached candidates.
 If the cache is unintialized, this will load the cache.
 If FORCE-REBUILD-CACHE is t, force reload the cache."
-  (when (or force-rebuild-cache
-            (eq 'uninitialized bibtex-actions--candidates-cache)
-            (eq 'uninitialized bibtex-actions--local-candidates-cache))
-    (bibtex-actions-refresh force-rebuild-cache))
+  (if force-rebuild-cache
+      (bibtex-actions-refresh force-rebuild-cache)
+    (progn
+      (when (eq 'uninitialized bibtex-actions--candidates-cache)
+        (bibtex-actions-refresh nil 'local))
+      (when (eq 'uninitialized bibtex-actions--local-candidates-cache)
+        (bibtex-actions-refresh nil 'global))))
   (seq-concatenate 'list
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))


### PR DESCRIPTION
bibtex-actions--process-display-formats refactor is exactly as before but refactored. 

Misc filenotify improvements, mostly that only the cache that is invalidated is recomputed when offering candidates.