### PR TITLE
Limit fields being parsed.

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -345,11 +345,12 @@ personal names of the form 'family, given'."
 (defun bibtex-actions--fields-to-parse ()
   "Determine the fields to parse from the template and field map"
   (let* ((fields-in-format (bibtex-actions--fields-in-formats))
-        (fields-for-symbols (list "doi" "url" bibtex-actions-file-variable))
-        (canonical-fields (seq-concatenate 'list fields-in-format fields-for-symbols)))
+         (fields-for-symbols (list "doi" "url" bibtex-actions-file-variable))
+         (canonical-fields (seq-concatenate 'list fields-in-format fields-for-symbols))
+         (equivalent-fields (cons '("author" "editor") bibtex-actions-field-map)))
     (seq-concatenate 'list
                      canonical-fields
-                     (seq-mapcat (lambda (field) (cdr (assoc field bibtex-actions-field-map)))
+                     (seq-mapcat (lambda (field) (cdr (assoc field equivalent-fields)))
                                  canonical-fields))))
 
 (defun bibtex-actions--format-candidates (files &optional context)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -329,6 +329,19 @@ personal names of the form 'family, given'."
          (car (split-string name ", "))))
      (split-string names " and ") ", ")))
 
+(defun bibtex-actions--fields-to-parse ()
+  "Determine the fields to parse from the template"
+  (cl-flet ((fields-for-format
+             (format-string)
+             (split-string
+              (s-format format-string
+                        (lambda (fields-string) (car (split-string fields-string ":")))))))
+    (cl-remove-duplicates
+     (seq-mapcat (lambda (format) (fields-for-format (cdr format)))
+              (seq-concatenate 'list
+                               bibtex-actions-template
+                               bibtex-actions-template-suffix)))))
+
 (defun bibtex-actions--format-candidates (files &optional context)
   "Format candidates from FILES, with optional hidden CONTEXT metadata.
 This both propertizes the candidates for display, and grabs the


### PR DESCRIPTION
This turned out to be straightforward.
This is what `(bibtex-actions--fields-to-parse)` produces with default templates,
```elisp
("author" "date" "title" "=key=" "=type=" "tags" "doi" "url" "file" "year" "issued" "id" "type" "keywords" "keyword")
```

Fix #231