### PR TITLE
Add basic template for default note fn

### DIFF
--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -21,6 +21,9 @@
 
 (require 'cl-lib)
 
+(declare-function bibtex-actions-get-entry "bibtex-actions")
+(declare-function bibtex-actions-get-value "bibtex-actions")
+
 ;;;; File related variables
 
 (defcustom bibtex-actions-file-open-function 'find-file
@@ -126,9 +129,11 @@ If you use 'org-roam' and 'org-roam-bibtex, you should use
           (caar (bibtex-actions-file--files-to-open-or-create
                  (list key)
                  bibtex-actions-notes-paths '("org"))))
-         (template "#+title: ${title}\n"))
-    ;; TODO how to insert the template-expanded content in the new file?
-    (funcall bibtex-actions-file-open-function file)))
+         (title (bibtex-actions-get-value "title" (bibtex-actions-get-entry key)))
+         (content
+          (concat "#+title: Notes on " title "\n")))
+    (funcall bibtex-actions-file-open-function file)
+    (insert content)))
 
 (provide 'bibtex-actions-file)
 ;;; bibtex-actions-file.el ends here


### PR DESCRIPTION
I made a mistake and pushed the initial commit to the main branch (sigh), but it was intended to go here.

So I'll finish it on this branch.

I'm not actually sure how best to do this with the template, but it's intended to be a simple thing, which is never-the-less compatible with `org-roam v2`.

Current code results in duplicate titles properties at the beginning, which is a Doom thing, so I can ignore that:

https://github.com/hlissner/doom-emacs/blob/develop/modules/editor/file-templates/README.org

FWIW, here's what inserting a note using the default capture template in `org-roam v2` looks like:

![image](https://user-images.githubusercontent.com/1134/130096544-551bf973-76f5-40e6-b460-52b37e9c234c.png)

So only real difference currently is it includes the property drawer for the file, and an org id.

But it should be easy enough to write, or borrow, an OR function for this.

Fix #239

Just FYI @aikrahguzar 