### PR TITLE
New layout for cached strings and overhaul of templates and formatting

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -114,7 +114,7 @@
 
 (defcustom bibtex-actions-template
   (cons
-   "${author editor:30}   ${date year issued:8}  ${title:48}"
+   "${author editor:30}   ${date year issued:4}  ${title:48}"
    "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
   "Configures formatting for the BibTeX entry.
 car is for the main body of the candidate and cdr is for suffix.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -116,7 +116,7 @@
   (cons
    "${author editor:30}   ${date year issued:4}  ${title:48}"
    "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
-  "Configures formatting for the BibTeX entry.
+  "Configures formatting for the bibliographic entry.
 car is for the main body of the candidate and cdr is for suffix.
 The same string is used for display and for search."
     :group 'bibtex-actions
@@ -272,7 +272,7 @@ offering the selection candidates"
     (seq-difference local-bib-files bibtex-actions-bibliography)))
 
 (defun bibtex-actions-get-value (fields item)
-  "Return biblatex FIELD value for ITEM."
+  "Return the first non nil biblatex field value for ITEM among FIELDS."
   (cl-flet ((get-value (field) (cdr (assoc-string field item 'case-fold))))
       (get-value (seq-find #'get-value fields))))
 
@@ -482,8 +482,11 @@ TEMPLATE."
             ;; Make sure we always return a string, even if empty.
             (field-value (or (bibtex-completion-clean-string
                               (bibtex-actions-get-value field-names entry))
-                             " ")))
-       (truncate-string-to-width field-value display-width 0 ?\s)))))
+                             ""))
+            (formatted-value (if (seq-intersection '("author" "editor") field-names)
+                                 (bibtex-actions-shorten-names field-value)
+                               field-value)))
+       (truncate-string-to-width formatted-value display-width 0 ?\s)))))
 
 ;;; At-point functions
 
@@ -555,7 +558,7 @@ With prefix, rebuild the cache before offering candidates."
 
 ;;;###autoload
 (defun bibtex-actions-open-entry (keys)
-  "Open BibTeX entry associated with the KEYS.
+  "Open bibliographic entry associated with the KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-select-keys
                       :rebuild-cache current-prefix-arg)))
@@ -607,7 +610,7 @@ With prefix, rebuild the cache before offering candidates."
 
 ;;;###autoload
 (defun bibtex-actions-insert-bibtex (keys)
-  "Insert BibTeX entry associated with the KEYS.
+  "Insert bibliographic entry associated with the KEYS.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-select-keys
                       :rebuild-cache current-prefix-arg)))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -272,7 +272,7 @@ offering the selection candidates"
     (seq-difference local-bib-files bibtex-actions-bibliography)))
 
 (defun bibtex-actions-get-value (fields item)
-  "Return the first non nil biblatex field value for ITEM among FIELDS."
+  "Return the first non nil biblatex field value for ITEM among FIELDS ."
   (cl-flet ((get-value (field) (cdr (assoc-string field item 'case-fold))))
       (get-value (seq-find #'get-value fields))))
 
@@ -456,7 +456,7 @@ are refreshed."
 ;;    https://github.com/tmalsburg/helm-bibtex/pull/367
 
 (defun bibtex-actions--format-width (format-string)
-  "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."
+  "Calculate minimal width needed by the FORMAT-STRING"
   (let ((content-width (apply #'+
                               (seq-map #'string-to-number
                                        (split-string format-string ":"))))
@@ -466,8 +466,8 @@ are refreshed."
 
 (defun bibtex-actions--format-entry (entry width format-string)
   "Formats a BibTeX ENTRY for display in results list.
-WIDTH is the width of the results list, and the display format is governed by
-TEMPLATE."
+WIDTH is the width for the * field, and the display format is governed by
+FORMAT-STRING."
   (s-format
    format-string
    (lambda (raw-field)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -1,4 +1,4 @@
-;;; bibtex-actions.el --- Biblographic commands based on completing-read -*- lexical-binding: t; -*-
+;;; bibtex-actions.el --- Bibliographic commands based on completing-read -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (C) 2021 Bruce D'Arcus
 ;;
@@ -323,7 +323,7 @@ key associated with each one."
   (let* ((main-width (bibtex-actions--format-width (car bibtex-actions-template)))
          (suffix-width (bibtex-actions--format-width (cdr bibtex-actions-template)))
          (symbols-width (string-width (bibtex-actions--symbols-string t t t)))
-         (star-width (- (frame-width) (+ 1 symbols-width main-width suffix-width))))
+         (star-width (- (frame-width) (+ 2 symbols-width main-width suffix-width))))
     (cl-loop for candidate being the hash-values of
              (parsebib-parse files :fields (bibtex-actions--fields-to-parse))
              using (hash-key citekey)
@@ -371,15 +371,18 @@ key associated with each one."
 
 (defun bibtex-actions--affixation (cands)
   "Add affixation prefix to CANDS."
-  (cl-loop
-   for candidate in cands
-   collect
-   (list candidate
-         (bibtex-actions--symbols-string
-          (string-match "has:files" candidate)
-          (string-match "has:note" candidate)
-          (string-match "has:link" candidate) )
-         "")))
+  (let ((width (string-width (bibtex-actions--symbols-string t t t))))
+    (cl-loop
+     for candidate in cands
+     collect
+     (list candidate
+           (truncate-string-to-width
+            (bibtex-actions--symbols-string
+             (string-match "has:files" candidate)
+             (string-match "has:note" candidate)
+             (string-match "has:link" candidate))
+            width 0 ?\s)
+           ""))))
 
 (defun bibtex-actions--symbols-string (has-files has-note has-link)
   "String for display from booleans HAS-FILES HAS-LINK HAS-NOTE."
@@ -392,7 +395,7 @@ key associated with each one."
              (list (thing-string has-files 'file)
                    (thing-string has-note 'note)
                    (thing-string has-link 'link)))
-     "	")))
+     "   ")))
 
 (defvar bibtex-actions--candidates-cache 'uninitialized
   "Store the global candidates list.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -266,9 +266,7 @@ offering the selection candidates"
            'bibtex-actions-history bibtex-actions-presets nil)))
     (cl-loop for choice in chosen
              ;; Collect citation keys of selected candidate(s).
-             collect (or (bibtex-actions-get-value
-                          "=key="
-                          (assoc choice candidates))
+             collect (or (cadr (assoc choice candidates))
              ;; Key is literal coming from embark, just pass it on
                           choice))))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -114,7 +114,7 @@
 
 (defcustom bibtex-actions-template
   (cons
-   "${author editor:30}   ${date year issued:4}  ${title:48}"
+   "${author editor:30}     ${date year issued:4}     ${title:48}"
    "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
   "Configures formatting for the bibliographic entry.
 car is for the main body of the candidate and cdr is for suffix.


### PR DESCRIPTION
For #237 

Mostly removes a lot of code.

`bibtex-actions-template` has a new type, so that might lead to type errors in a long session. 
Preferably test in a new session if everything works. Everything seems to work fine for me.  