### PR TITLE
Adjust use of ba-get-value default notes function

### DIFF
--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -129,7 +129,7 @@ If you use 'org-roam' and 'org-roam-bibtex, you should use
           (caar (bibtex-actions-file--files-to-open-or-create
                  (list key)
                  bibtex-actions-notes-paths '("org"))))
-         (title (bibtex-actions-get-value "title" (bibtex-actions-get-entry key)))
+         (title (bibtex-actions-get-value '("title") (bibtex-actions-get-entry key)))
          (content
           (concat "#+title: Notes on " title "\n")))
     (funcall bibtex-actions-file-open-function file)


### PR DESCRIPTION
Should fix #242 

It was result for `bibtex-actions-get-value` accepting a list of fields now. I checked the main file but not the other ones. I have now and it seems it was the only remaining usage not fixed.  