### PR TITLE
Customizable field display + better fix for symbol alignment

### DIFF
--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -129,7 +129,7 @@ If you use 'org-roam' and 'org-roam-bibtex, you should use
           (caar (bibtex-actions-file--files-to-open-or-create
                  (list key)
                  bibtex-actions-notes-paths '("org"))))
-         (title (bibtex-actions-get-value '("title") (bibtex-actions-get-entry key)))
+         (title (bibtex-actions-get-value "title" (bibtex-actions-get-entry key)))
          (content
           (concat "#+title: Notes on " title "\n")))
     (funcall bibtex-actions-file-open-function file)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -123,7 +123,7 @@ The same string is used for display and for search."
     :type  '(cons string string))
 
 (defcustom bibtex-actions-display-transform-functions
-  '((t  . bibtex-completion-clean-string)
+  '((t  . bibtex-actions-clean-string)
     (("author" "editor") . bibtex-actions-shorten-names))
   "This variable configures the transformation of field values from raw values
 in bib files to those displayed when using `bibtex-actions-select-keys'.
@@ -303,7 +303,14 @@ The value is transformed using `bibtex-actions-display-transform-functions'"
                       (funcall (cdr fun) string)
                     string))
                 bibtex-actions-display-transform-functions
-                (bibtex-actions-get-value field item))))
+            ;; Make sure we always return a string, even if empty.
+                (or (bibtex-actions-get-value field item) ""))))
+
+;; Lifted from bibtex-completion
+(defun bibtex-actions-clean-string (s)
+  "Remove quoting brackets and superfluous whitespace from string S."
+  (replace-regexp-in-string "[\n\t ]+" " "
+         (replace-regexp-in-string "[\"{}]+" "" s)))
 
 (defun bibtex-actions-get-entry (key)
   "Return the cached entry for KEY."
@@ -514,7 +521,7 @@ FORMAT-STRING."
                                field-width
                              width))
             ;; Make sure we always return a string, even if empty.
-            (display-value (or (bibtex-actions-display-value field-names entry) "")))
+            (display-value (bibtex-actions-display-value field-names entry)))
        (truncate-string-to-width display-value display-width 0 ?\s)))))
 
 ;;; At-point functions

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -134,16 +134,14 @@ All functions that match a particular field are run in order."
 
 (defcustom bibtex-actions-symbols
   `((file  .  ("⌘" . " "))
-    (note .   ("✎ " . " "))
+    (note .   ("✎" . " "))
     (link .   ("🔗" . "  ")))
   "Configuration alist specifying which symbol or icon to pick for a bib entry.
 This leaves room for configurations where the absense of an item
 may be indicated with the same icon but a different face.
 
 To avoid alignment issues make sure that both the car and cdr of a symbol have
-the same width. In addition, the `string-width' of the symbols should be
-accurate for the font being used. See the documentation of `string-wdith'
-for the caveats."
+the same width."
   :group 'bibtex-actions
   :type '(alist :key-type string
                 :value-type (choice (string :tag "Symbol"))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -122,13 +122,28 @@ The same string is used for display and for search."
     :group 'bibtex-actions
     :type  '(cons string string))
 
+(defcustom bibtex-actions-display-transform-functions
+  '((t  . bibtex-completion-clean-string)
+    (("author" "editor") . bibtex-actions-shorten-names))
+  "This variable configures the transformation of field values from raw values
+in bib files to those displayed when using `bibtex-actions-select-keys'.
+All functions that match a particular field are run in order."
+  :group 'bibtex-actions
+  :type '(alist :key-type   (choice (const t) (repeat string))
+                :value-type function))
+
 (defcustom bibtex-actions-symbols
   `((file  .  ("📄" . "  "))
     (note .   ("✎" . " "))
     (link .   ("🔗" . "  ")))
   "Configuration alist specifying which symbol or icon to pick for a bib entry.
 This leaves room for configurations where the absense of an item
-may be indicated with the same icon but a different face."
+may be indicated with the same icon but a different face.
+
+To avoid alignment issues make sure that both the car and cdr of a symbol have
+the same width. In addition, the `string-width' of the symbols should be
+accurate for the font being used. See the documentation of `string-wdith'
+for the caveats."
   :group 'bibtex-actions
   :type '(alist :key-type string
                 :value-type (choice (string :tag "Symbol"))))
@@ -271,10 +286,26 @@ offering the selection candidates"
            (bibtex-completion-find-local-bibliography))))
     (seq-difference local-bib-files bibtex-actions-bibliography)))
 
-(defun bibtex-actions-get-value (fields item)
-  "Return the first non nil biblatex field value for ITEM among FIELDS ."
-  (cl-flet ((get-value (field) (cdr (assoc-string field item 'case-fold))))
-      (get-value (seq-find #'get-value fields))))
+(defun bibtex-actions-get-value (field item)
+  "Return the FIELD value for ITEM."
+  (cdr (assoc-string field item 'case-fold)))
+
+(defun bibtex-actions-has-a-value (fields item)
+  "Retuns the first field that has a value in ITEM among FIELDS ."
+  (seq-find (lambda (field) (bibtex-actions-get-value field item)) fields))
+
+(defun bibtex-actions-display-value (fields item)
+  "Return the first non nil value for ITEM among FIELDS .
+
+The value is transformed using `bibtex-actions-display-transform-functions'"
+  (let ((field (bibtex-actions-has-a-value fields item)))
+    (seq-reduce (lambda (string fun)
+                  (if (or (eq t (car fun))
+                          (member field (car fun)))
+                      (funcall (cdr fun) string)
+                    string))
+                bibtex-actions-display-transform-functions
+                (bibtex-actions-get-value field item))))
 
 (defun bibtex-actions-get-entry (key)
   "Return the cached entry for KEY."
@@ -309,12 +340,10 @@ personal names of the form 'family, given'."
                        (cdr bibtex-actions-template)))))
 
 (defun bibtex-actions--fields-to-parse ()
-  "Determine the fields to parse from the template and field map."
-  (let* ((fields-in-format (bibtex-actions--fields-in-formats))
-         (fields-for-symbols (list "doi" "url" bibtex-actions-file-variable)))
-    (seq-concatenate 'list
-                     fields-in-format
-                     fields-for-symbols)))
+  "Determine the fields to parse from the template."
+  (seq-concatenate 'list
+                   (bibtex-actions--fields-in-formats)
+                   (list "doi" "url" bibtex-actions-file-variable)))
 
 (defun bibtex-actions--format-candidates (files &optional context)
   "Format candidates from FILES, with optional hidden CONTEXT metadata.
@@ -330,7 +359,7 @@ key associated with each one."
              collect
              (let* ((files
                      (when (or (bibtex-actions-get-value
-                                (list bibtex-actions-file-variable) candidate)
+                                bibtex-actions-file-variable candidate)
                                (bibtex-actions-file--files-for-key
                                 citekey bibtex-actions-library-paths bibtex-actions-file-extensions))
                        " has:files"))
@@ -338,7 +367,7 @@ key associated with each one."
                      (when (bibtex-actions-file--files-for-key
                             citekey bibtex-actions-notes-paths bibtex-actions-file-extensions)
                        " has:notes"))
-                    (link (when (bibtex-actions-get-value '("doi" "url") candidate)
+                    (link (when (bibtex-actions-has-a-value '("doi" "url") candidate)
                             "has:link"))
                     (candidate-main
                      (bibtex-actions--format-entry
@@ -483,13 +512,8 @@ FORMAT-STRING."
                                field-width
                              width))
             ;; Make sure we always return a string, even if empty.
-            (field-value (or (bibtex-completion-clean-string
-                              (bibtex-actions-get-value field-names entry))
-                             ""))
-            (formatted-value (if (seq-intersection '("author" "editor") field-names)
-                                 (bibtex-actions-shorten-names field-value)
-                               field-value)))
-       (truncate-string-to-width formatted-value display-width 0 ?\s)))))
+            (display-value (or (bibtex-actions-display-value field-names entry) "")))
+       (truncate-string-to-width display-value display-width 0 ?\s)))))
 
 ;;; At-point functions
 
@@ -577,11 +601,11 @@ With prefix, rebuild the cache before offering candidates."
   (cl-loop for key in keys do
            (let* ((entry (bibtex-actions-get-entry key))
                   (doi
-                   (bibtex-actions-get-value '("doi") entry))
+                   (bibtex-actions-get-value "doi" entry))
                   (doi-url
                    (when doi
                      (concat "https://doi.org/" doi)))
-                  (url (bibtex-actions-get-value '("url") entry))
+                  (url (bibtex-actions-get-value "url" entry))
                   (link (or doi-url url)))
              (if link
                  (browse-url-default-browser link)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -507,7 +507,7 @@ are refreshed."
 
 (defun bibtex-actions--fit-to-width (value width)
   "Propertize the string VALUE so that only the WIDTH columns are visible"
-  (let* ((truncated-value (truncate-string-to-width value width 0 ?\s))
+  (let* ((truncated-value (truncate-string-to-width value width))
          (display-value (truncate-string-to-width truncated-value width 0 ?\s)))
     (if (> (string-width value) width)
         (concat display-value (propertize (substring value (length truncated-value))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -505,6 +505,15 @@ are refreshed."
                                                   (lambda (_) "")))))
     (+ content-width whitespace-width)))
 
+(defun bibtex-actions--fit-to-width (value width)
+  "Propertize the string VALUE so that only the WIDTH columns are visible"
+  (let* ((truncated-value (truncate-string-to-width value width 0 ?\s))
+         (display-value (truncate-string-to-width truncated-value width 0 ?\s)))
+    (if (> (string-width value) width)
+        (concat display-value (propertize (substring value (length truncated-value))
+                                          'invisible t))
+      display-value)))
+
 (defun bibtex-actions--format-entry (entry width format-string)
   "Formats a BibTeX ENTRY for display in results list.
 WIDTH is the width for the * field, and the display format is governed by
@@ -522,7 +531,7 @@ FORMAT-STRING."
                              width))
             ;; Make sure we always return a string, even if empty.
             (display-value (bibtex-actions-display-value field-names entry)))
-       (truncate-string-to-width display-value display-width 0 ?\s)))))
+       (bibtex-actions--fit-to-width display-value display-width)))))
 
 ;;; At-point functions
 


### PR DESCRIPTION
First one is an experiment I am not too sure about. I was a bit bothered about the fact that the shortening of author and editor names is a special case. So I created a `defcustom` that controls transforming the fields from the raw parsed string to one for display and now name shortening goes through it. I like the uniformity but not sure if it anyone would want to do something with it. 

As a related change `bibtex-actions-get-value` is back to accepting a single field. There are now two related functions, `bibtex-action-has-a-value` which accepts a list of fields and returns the first field for which the item has a value and `bibtex-actions-display-value` which accpets also accepts a list of fields and returns the display string. 

I also managed to find a more robust solution for alignment issues for the symbols using the display property. This should now work correctly if a symbol with string-width `n` doesn't occupy more than `n+1` columns on screen and there is some padding available. The padding will be reduced by whatever fraction the symbol overflows. It still does require that the symbols for the absence or presence of a thing both have the same width.