### PR TITLE
refactor bibtex-actions-open

### DIFF
--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -129,7 +129,7 @@ If you use 'org-roam' and 'org-roam-bibtex, you should use
           (caar (bibtex-actions-file--files-to-open-or-create
                  (list key)
                  bibtex-actions-notes-paths '("org"))))
-         (title (bibtex-actions-get-value '("title") (bibtex-actions-get-entry key)))
+         (title (bibtex-actions-get-value "title" (bibtex-actions-get-entry key)))
          (content
           (concat "#+title: Notes on " title "\n")))
     (funcall bibtex-actions-file-open-function file)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -587,12 +587,13 @@ FORMAT-STRING."
          (links
           (cl-loop for key in keys collect
                    (bibtex-actions-get-link key)))
-        (resource (completing-read "Related resources: " (append files links))))
-        (cond ((string-search "http" resource 0)
-           (browse-url resource))
-          ((equal (file-name-extension resource) (or "org" "md"))
-           (funcall bibtex-actions-open-file-function resource))
-          (t (bibtex-actions-file-open-external resource)))))
+        (resources (completing-read-multiple "Related resources: " (append files links))))
+    (cl-loop for resource in resources do
+             (cond ((string-search "http" resource 0)
+                    (browse-url resource))
+                   ((equal (file-name-extension resource) (or "org" "md"))
+                    (funcall bibtex-actions-open-file-function resource))
+                   (t (bibtex-actions-file-open-external resource))))))
 
 ;;;###autoload
 (defun bibtex-actions-open-library-files (keys)


### PR DESCRIPTION
Initial commit implement #229 as a simple flat list of related resources.

Still need:

1. ~add links~
2. `bibtex-actions-select-file`? 
3. probably also add a `consult--multi` option if present, rather than requiring consult; alternately, perhaps a better first step is to just add an annotation function to the simple flat version

If the latter, the annotation could just be types:

- DOI
- URL
- note
- file

...?