### PR TITLE
feat: add new format-entry function, note template

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,16 +141,6 @@ If you prefer to use a hydra-based in-buffer interface, you can also use that pr
 (setq org-cite-activate-processor 'org-ref-cite-follow)
 #+END_SRC
 
-** Test Script
-    :PROPERTIES:
-    :CUSTOM_ID: test-script
-    :END:
-
-The repository =test= directory also includes a script you can use to run this and associated packages in the =emacs -Q= sandbox.
-To do that, simply run =./run.sh= from the =test= directory.
-By default, this will use selectrum as the completion system.
-If you would like to try vertico instead, just do =M-x vertico-mode=.
-
 ** Rich UI
     :PROPERTIES:
     :CUSTOM_ID: rich-ui
@@ -168,17 +158,26 @@ For the prefix, you can filter for associated PDFs or notes using =has:pdf= or =
 #+CAPTION: UI sections
 [[file:images/ui-segments.png]]
 
-You can configure both of the last two similar as you do with bibtex-completion.
+*** Templates
+
+The =bibtex-actions-templates= variable configures formatting for these sections, as well as the default note function.
+Here's the defaults:
 
 #+BEGIN_SRC emacs-lisp
-  (setq bibtex-actions-template '((t . " ${title:*}")))
-  (setq bibtex-actions-template-suffix '((t . "          ${=key=:15}")))
+(setq bibtex-actions-templates
+      '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
+        (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords:*}")
+        (note . "#+title: Notes on ${author editor}, ${title}")))
 #+END_SRC
 
 Note:
 
-1. the asterisk signals to the formatter to use available space for the column: you should only use this on one field total, across the two templates, for the formatting to work correctly.
-2. the inclusion of CSL-JSON support is currently experimental, and relies on =bibtex-actions-field-map= variable to map among the different supported formats, and is subject to change.
+1. You may include multiple variables in a field; the formatter will print the first one it finds.
+2. If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
+3. The asterisk signals to the formatter to use available space for the column.
+4. The note template does not take widths, as formatting is inline there rather than columnar.
+
+*** Icons
 
 By default, this UI is plain text, but you can configure it to use icons instead.
 
@@ -203,6 +202,16 @@ Here's how to configure it to use =all-the-icons=:
        "Face for obscuring/dimming icons"
        :group 'all-the-icons-faces)
 #+END_SRC
+
+** Test Script
+    :PROPERTIES:
+    :CUSTOM_ID: test-script
+    :END:
+
+The repository =test= directory also includes a script you can use to run this and associated packages in the =emacs -Q= sandbox.
+To do that, simply run =./run.sh= from the =test= directory.
+By default, this will use selectrum as the completion system.
+If you would like to try vertico instead, just do =M-x vertico-mode=.
 
 ** History and predefined searches
     :PROPERTIES:

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -24,6 +24,8 @@
 
 (declare-function bibtex-actions-get-entry "bibtex-actions")
 (declare-function bibtex-actions-get-value "bibtex-actions")
+(declare-function bibtex-actions-get-template "bibtex-actions")
+(declare-function bibtex-actions--format-entry-no-widths "bibtex-actions")
 
 ;;;; File related variables
 
@@ -165,9 +167,13 @@ use 'orb-edit-note' for this value."
             (file-exists (file-exists-p file)))
       (funcall bibtex-actions-file-open-function file)
     (let* ((uuid (org-id-new))
-           (title (bibtex-actions-get-value "title" (bibtex-actions-get-entry key)))
+           (entry (bibtex-actions-get-entry key))
+           (note-title
+            (bibtex-actions--format-entry-no-widths
+             entry
+             (bibtex-actions-get-template 'note)))
            (content
-            (concat ":PROPERTIES:\n:ID:  " uuid "\n:END:\n#+title: Notes on " title "\n")))
+            (concat ":PROPERTIES:\n:ID:  " uuid "\n:END:\n" note-title "\n")))
       (funcall bibtex-actions-file-open-function file)
       (insert content))))
 

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -45,7 +45,7 @@
   :type '(boolean))
 
 (defcustom bibtex-actions-file-open-note-function
-  'bibtex-actions-file-open-notes-default
+  'bibtex-actions-file-open-notes-default-org
   "Function to open and existing or create a new note.
 
 If you use 'org-roam' and 'org-roam-bibtex', for example, you can
@@ -158,7 +158,7 @@ use 'orb-edit-note' for this value."
                   nil 0 nil
                   file)))
 
-(defun bibtex-actions-file-open-notes-default (key)
+(defun bibtex-actions-file-open-notes-default-org (key)
   "Open a note file from KEY."
   (if-let* ((file
              (caar (bibtex-actions-file--files-to-open-or-create
@@ -168,12 +168,12 @@ use 'orb-edit-note' for this value."
       (funcall bibtex-actions-file-open-function file)
     (let* ((uuid (org-id-new))
            (entry (bibtex-actions-get-entry key))
-           (note-title
+           (note-meta
             (bibtex-actions--format-entry-no-widths
              entry
              (bibtex-actions-get-template 'note)))
            (content
-            (concat ":PROPERTIES:\n:ID:  " uuid "\n:END:\n" note-title "\n")))
+            (concat ":PROPERTIES:\n:ID:  " uuid "\n:END:\n" note-meta "\n")))
       (funcall bibtex-actions-file-open-function file)
       (insert content))))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -449,13 +449,10 @@ has not yet been created")
 
 (defun bibtex-actions-get-entry (key)
   "Return the cached entry for KEY."
-  (if (or (eq 'uninitialized bibtex-actions--candidates-cache)
-          (eq 'uninitialized bibtex-actions--local-candidates-cache))
-      (message "Something is wrong; your library is not initialized.")
-    (cddr (seq-find
-           (lambda (entry)
-             (string-equal key (cadr entry)))
-           (bibtex-actions--get-candidates)))))
+  (cddr (seq-find
+         (lambda (entry)
+           (string-equal key (cadr entry)))
+         (bibtex-actions--get-candidates))))
 
 (defun bibtex-actions-get-template (template-name)
   "Return template string for TEMPLATE-NAME."
@@ -467,10 +464,10 @@ If the cache is unintialized, this will load the cache.
 If FORCE-REBUILD-CACHE is t, force reload the cache."
   (if force-rebuild-cache
       (bibtex-actions-refresh force-rebuild-cache)
-      (when (eq 'uninitialized bibtex-actions--candidates-cache)
-        (bibtex-actions-refresh nil 'global))
-      (when (eq 'uninitialized bibtex-actions--local-candidates-cache)
-        (bibtex-actions-refresh nil 'local)))
+    (when (eq 'uninitialized bibtex-actions--candidates-cache)
+      (bibtex-actions-refresh nil 'global))
+    (when (eq 'uninitialized bibtex-actions--local-candidates-cache)
+      (bibtex-actions-refresh nil 'local)))
   (seq-concatenate 'list
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -114,14 +114,15 @@
 
 
 (defcustom bibtex-actions-template
-  (cons
-   "${author editor:30}     ${date year issued:4}     ${title:48}"
-   "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
+  '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
+    (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
+    (note . "Notes on ${author editor}, ${title}"))
   "Configures formatting for the bibliographic entry.
-car is for the main body of the candidate and cdr is for suffix.
-The same string is used for display and for search."
+
+The main and suffix templates are for candidate display, and note
+for the title field for new notes."
     :group 'bibtex-actions
-    :type  '(cons string string))
+    :type  '(alist :key-type string))
 
 (defcustom bibtex-actions-display-transform-functions
   ;; TODO change this name, as it might be confusing?

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -555,6 +555,14 @@ FORMAT-STRING."
             (display-value (bibtex-actions-display-value field-names entry)))
        (bibtex-actions--fit-to-width display-value display-width)))))
 
+(defun bibtex-actions--format-entry-no-widths (entry format-string)
+  "Format ENTRY for display per FORMAT-STRING."
+  (s-format
+   format-string
+   (lambda (raw-field)
+     (let ((field-names (split-string raw-field "[ ]+")))
+       (bibtex-actions-display-value field-names entry)))))
+
 ;;; At-point functions
 
 ;;; Org-cite

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -113,7 +113,7 @@
   :type '(boolean))
 
 
-(defcustom bibtex-actions-template
+(defcustom bibtex-actions-templates
   '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
     (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
     (note . "Notes on ${author editor}, ${title}"))
@@ -339,8 +339,8 @@ personal names of the form 'family, given'."
                         (lambda (fields-string) (car (split-string fields-string ":"))))
              "[ ]+")))
      (seq-mapcat #'fields-for-format
-                 (list (car bibtex-actions-template)
-                       (cdr bibtex-actions-template)))))
+                 (list (bibtex-actions-get-template 'main)
+                       (bibtex-actions-get-template 'suffix)))))
 
 (defun bibtex-actions--fields-to-parse ()
   "Determine the fields to parse from the template."
@@ -355,8 +355,8 @@ key associated with each one."
   (let* ((candidates ())
          (raw-candidates
           (parsebib-parse files :fields (bibtex-actions--fields-to-parse)))
-         (main-width (bibtex-actions--format-width (car bibtex-actions-template)))
-         (suffix-width (bibtex-actions--format-width (cdr bibtex-actions-template)))
+         (main-width (bibtex-actions--format-width (bibtex-actions-get-template 'main)))
+         (suffix-width (bibtex-actions--format-width (bibtex-actions-get-template 'suffix)))
          (symbols-width (string-width (bibtex-actions--symbols-string t t t)))
          (star-width (- (frame-width) (+ 2 symbols-width main-width suffix-width))))
     (maphash
@@ -377,12 +377,12 @@ key associated with each one."
                (bibtex-actions--format-entry
                 entry
                 star-width
-                (car bibtex-actions-template)))
+                (bibtex-actions-get-template 'main)))
               (candidate-suffix
                (bibtex-actions--format-entry
                 entry
                 star-width
-                (cdr bibtex-actions-template)))
+                (bibtex-actions-get-template 'suffix)))
               ;; We display this content already using symbols; here we add back
               ;; text to allow it to be searched, and citekey to ensure uniqueness
               ;; of the candidate.
@@ -456,6 +456,10 @@ has not yet been created")
            (lambda (entry)
              (string-equal key (cadr entry)))
            (bibtex-actions--get-candidates)))))
+
+(defun bibtex-actions-get-template (template-name)
+  "Return template string for TEMPLATE-NAME."
+  (cdr (assoc template-name bibtex-actions-templates)))
 
 (defun bibtex-actions--get-candidates (&optional force-rebuild-cache)
   "Get the cached candidates.

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -116,7 +116,7 @@
 (defcustom bibtex-actions-templates
   '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
     (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
-    (note . "Notes on ${author editor}, ${title}"))
+    (note . "#+title: Notes on ${author editor}, ${title}"))
   "Configures formatting for the bibliographic entry.
 
 The main and suffix templates are for candidate display, and note


### PR DESCRIPTION
Per #269, this adds a template for formatting new note titles, and a function to handle it.

It has occurred to me maybe this function should be called `format-entry`, and the original one renamed `format-entry-columns`?

Note: there's a [little change](https://github.com/bdarcus/bibtex-actions/pull/274/commits/6ddbe996b6d6d3c6b75379ac0ad7e80caa5b0c92#diff-43b58707c1adce5c6f3e1ed8d97ea5665182d94767472f7c196d630ff3ca0c3cL452) I made here that exposed a much bigger infinite recursion bug that I can't figure out how to fix otherwise.

```elisp
ELISP> (bibtex-actions--format-candidates bibtex-actions-bibliography)
*** Eval error ***  Lisp nesting exceeds ‘max-lisp-eval-depth’
```

Backtrace:

```elisp
Debugger entered--Lisp error: (error "Lisp nesting exceeds ‘max-lisp-eval-depth’")
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_17>("${author editor:30}")
  replace-regexp-in-string("\\$\\({\\([^}]+\\)}\\|[0-9]+\\)" #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_17> "${author editor:30}     ${date year issued:4}     ..." t t)
  s-format("${author editor:30}     ${date year issued:4}     ..." #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_20>)
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21>("${author editor:30}     ${date year issued:4}     ...")
  mapcar(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21> ("${author editor:30}     ${date year issued:4}     ..." "          ${=key= id:15}    ${=type=:12}    ${tags..."))
  #f(compiled-function #'sequence #<bytecode 0x18574107428dcbb4>)(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21> ("${author editor:30}     ${date year issued:4}     ..." "          ${=key= id:15}    ${=type=:12}    ${tags..."))
  apply(#f(compiled-function #'sequence #<bytecode 0x18574107428dcbb4>) #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21> ("${author editor:30}     ${date year issued:4}     ..." "          ${=key= id:15}    ${=type=:12}    ${tags...") nil)
  seq-map(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21> ("${author editor:30}     ${date year issued:4}     ..." "          ${=key= id:15}    ${=type=:12}    ${tags..."))
  seq-mapcat(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_21> ("${author editor:30}     ${date year issued:4}     ..." "          ${=key= id:15}    ${=type=:12}    ${tags..."))
  bibtex-actions--fields-in-formats()
  bibtex-actions--fields-to-parse()
  bibtex-actions--format-candidates(("/home/bruce/org/bib/newer.bib"))
```