### PR TITLE
fix: change functions to take entry, decouple cache from formatting

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
    :CUSTOM_ID: features
    :END:
 
-This package provides a completing-read front-end to browse and act on BibTeX, BibLaTeX, and CSL JSON bibliographic data.
+This package provides a completing-read front-end to browse and act on BibTeX, BibLaTeX, and CSL JSON bibliographic data, and LaTeX, markdown, and org-cite editing support.
 
 When used with vertico (or selectrum), embark, and marginalia, it provides similar functionality to helm-bibtex and ivy-bibtex: quick filtering and selecting of bibliographic entries from the minibuffer, and the option to run different commands against them.
 

--- a/README.org
+++ b/README.org
@@ -113,7 +113,10 @@ In other supported modes, it will work the same as the embark option above.
   :after (embark oc)
   :config
   (setq bibtex-actions-bibliography my/bibs
-        org-cite-global-bibliography my/bibs))
+        org-cite-global-bibliography my/bibs
+        org-cite-insert-processor 'oc-bibtex-actions
+        org-cite-follow-processor 'oc-bibtex-actions
+        org-cite-activate-processor 'basic))
 
 ;; Use consult-completing-read for enhanced interface.
 (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -137,7 +137,7 @@ use 'orb-edit-note' for this value."
   "Find files related to a list of KEYS in DIRS with extension in EXTENSIONS."
   (seq-mapcat
    (lambda (key)
-     (bibtex-actions-file--files-for-key key dirs extensions)) keys))
+     (bibtex-actions-file--files-for-key (car key) dirs extensions)) keys))
 
 ;;;; Opening and creating files functions
 
@@ -158,16 +158,16 @@ use 'orb-edit-note' for this value."
                   nil 0 nil
                   file)))
 
-(defun bibtex-actions-file-open-notes-default-org (key)
-  "Open a note file from KEY."
+(defun bibtex-actions-file-open-notes-default-org (key-entry)
+  "Open a note file from KEY-ENTRY."
   (if-let* ((file
              (caar (bibtex-actions-file--files-to-open-or-create
-                    (list key)
+                    (list key-entry)
                     bibtex-actions-notes-paths '("org"))))
             (file-exists (file-exists-p file)))
       (funcall bibtex-actions-file-open-function file)
     (let* ((uuid (org-id-new))
-           (entry (bibtex-actions-get-entry key))
+           (entry (cdr key-entry))
            (note-meta
             (bibtex-actions--format-entry-no-widths
              entry

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -99,7 +99,7 @@ use 'orb-edit-note' for this value."
               (lambda (directory)
                 (expand-file-name
                  (concat
-                  (bibtex-actions-get-value "=Key=" entry) "." extension) directory))
+                  (bibtex-actions-get-value "=key=" entry) "." extension) directory))
               dirs)))
     (let* ((results-key (seq-mapcat
                          #'possible-file-names-with-extension
@@ -110,7 +110,7 @@ use 'orb-edit-note' for this value."
             (when file-field (funcall bibtex-actions-file-parser-function dirs file-field))))
       (append results-key results-file))))
 
-(defun bibtex-actions-file--files-for-key (entry dirs extensions)
+(defun bibtex-actions-file--files-for-entry (entry dirs extensions)
     "Find files related to ENTRY in DIRS with extension in EXTENSIONS."
     (seq-filter #'file-exists-p
                 (bibtex-actions-file--possible-names entry dirs extensions)))
@@ -132,12 +132,11 @@ use 'orb-edit-note' for this value."
                   possible-files)))))
     (seq-mapcat #'files-for-key keys)))
 
-
-(defun bibtex-actions-file--files-for-multiple-keys (keys dirs extensions)
-  "Find files related to a list of KEYS in DIRS with extension in EXTENSIONS."
+(defun bibtex-actions-file--files-for-multiple-entries (keys-entries dirs extensions)
+  "Find files related to a list of KEYS-ENTRIES in DIRS with extension in EXTENSIONS."
   (seq-mapcat
-   (lambda (key)
-     (bibtex-actions-file--files-for-key (car key) dirs extensions)) keys))
+   (lambda (key-entry)
+     (bibtex-actions-file--files-for-entry (cdr key-entry) dirs extensions)) keys-entries))
 
 ;;;; Opening and creating files functions
 

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -160,6 +160,8 @@ use 'orb-edit-note' for this value."
 
 (defun bibtex-actions-file-open-notes-default-org (key-entry)
   "Open a note file from KEY-ENTRY."
+  ;; modify when this addressed:
+  ;; https://github.com/org-roam/org-roam-bibtex/issues/211
   (if-let* ((file
              (caar (bibtex-actions-file--files-to-open-or-create
                     (list key-entry)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -91,29 +91,29 @@ use 'orb-edit-note' for this value."
           (expand-file-name file dir)) files))
      dirs)))
 
-(defun bibtex-actions-file--possible-names (key dirs extensions)
-  "Possible names for files correponding to KEY with EXTENSIONS in DIRS."
+(defun bibtex-actions-file--possible-names (entry dirs extensions)
+  "Possible names for files correponding to ENTRY with EXTENSIONS in DIRS."
   (cl-flet ((possible-file-names-with-extension
              (extension)
              (seq-map
               (lambda (directory)
                 (expand-file-name
-                 (concat key "." extension) directory))
+                 (concat
+                  (bibtex-actions-get-value "=Key=" entry) "." extension) directory))
               dirs)))
     (let* ((results-key (seq-mapcat
                          #'possible-file-names-with-extension
                          extensions))
-           (entry (bibtex-actions-get-entry key))
            (file-field (bibtex-actions-get-value
                         bibtex-actions-file-variable entry))
            (results-file
             (when file-field (funcall bibtex-actions-file-parser-function dirs file-field))))
       (append results-key results-file))))
 
-(defun bibtex-actions-file--files-for-key (key dirs extensions)
-    "Find files related to KEY in DIRS with extension in EXTENSIONS."
+(defun bibtex-actions-file--files-for-key (entry dirs extensions)
+    "Find files related to ENTRY in DIRS with extension in EXTENSIONS."
     (seq-filter #'file-exists-p
-                (bibtex-actions-file--possible-names key dirs extensions)))
+                (bibtex-actions-file--possible-names entry dirs extensions)))
 
 (defun bibtex-actions-file--files-to-open-or-create (keys dirs extensions)
   "Find files related to a list of KEYS in DIRS with extension in EXTENSIONS."

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -230,18 +230,19 @@ and nil means no action."
 
 ;;; Completion functions
 
-(cl-defun bibtex-actions-select-keys (&optional &key rebuild-cache)
-  "Read bibliographic entries for completing bibliographic entries.
+(cl-defun bibtex-actions-select-refs (&optional &key rebuild-cache)
+  "Select bibliographic references.
 
-This provides a wrapper around 'completing-read-multiple', with
-the following optional arguments:
+Provides a wrapper around 'completing-read-multiple, and returns
+an alist of key-entry, where the entry is a field-value alist.
+
+Therefore, for each returned candidate, 'car' is the citekey, and
+'cdr' is an alist of structured data.
+
+Includes the following optional argument:
 
 'REBUILD-CACHE' if t, forces rebuilding the cache before
-offering the selection candidates.
-
-It returns an alist of key-entry, where the entry is a
-field-value alist. Therefore, for each returned candidate, 'car'
-is the citekey, and 'cdr' is the alist of structured data."
+offering the selection candidates."
   (let* ((crm-separator "\\s-*&\\s-*")
          (candidates (bibtex-actions--get-candidates rebuild-cache))
          (chosen
@@ -594,7 +595,7 @@ FORMAT-STRING."
 (defun bibtex-actions-open (keys-entries)
   "Open related resource (link or file) for KEYS-ENTRIES."
   ;; TODO add links
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (let* ((files
          (bibtex-actions-file--files-for-multiple-keys
@@ -621,7 +622,7 @@ FORMAT-STRING."
  "Open library files associated with the KEYS-ENTRIES.
 
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (let ((files
          (bibtex-actions-file--files-for-multiple-keys
@@ -643,7 +644,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-open-notes (keys-entries)
   "Open notes associated with the KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (dolist (key-entry keys-entries)
     ;; REVIEW doing this means the function won't be compatible with, for
@@ -654,7 +655,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-open-entry (keys-entries)
   "Open bibliographic entry associated with the KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
  (bibtex-completion-show-entry (caar keys-entries)))
 
@@ -664,7 +665,7 @@ With prefix, rebuild the cache before offering candidates."
 
 With prefix, rebuild the cache before offering candidates."
   ;;      (browse-url-default-browser "https://google.com")
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (dolist (key-entry keys-entries)
     (let* ((doi
@@ -682,7 +683,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-insert-citation (keys-entries)
   "Insert citation for the KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   ;; TODO
   (bibtex-completion-insert-citation
@@ -693,7 +694,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-insert-reference (keys-entries)
   "Insert formatted reference(s) associated with the KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (bibtex-completion-insert-reference
    (bibtex-actions--extract-keys
@@ -703,7 +704,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-insert-key (keys-entries)
   "Insert BibTeX KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
  (bibtex-completion-insert-key
   (bibtex-actions--extract-keys
@@ -713,7 +714,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-insert-bibtex (keys-entries)
   "Insert bibliographic entry associated with the KEYS-ENTRIES.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
  (bibtex-completion-insert-bibtex
   (bibtex-actions--extract-keys
@@ -723,7 +724,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun bibtex-actions-add-pdf-attachment (keys-entries)
   "Attach PDF(s) associated with the KEYS-ENTRIES to email.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
  (bibtex-completion-add-PDF-attachment
   (bibtex-actions--extract-keys
@@ -735,7 +736,7 @@ With prefix, rebuild the cache before offering candidates."
 The PDF can be added either from an open buffer, a file, or a
 URL.
 With prefix, rebuild the cache before offering candidates."
-  (interactive (list (bibtex-actions-select-keys
+  (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (bibtex-completion-add-pdf-to-library
    (bibtex-actions--extract-keys
@@ -754,6 +755,7 @@ With prefix, rebuild the cache before offering candidates."
   "Run the default action on citation keys found at point."
   (interactive)
   (if-let ((keys (cdr (bibtex-actions-citation-key-at-point))))
+      ;; FIX how?
       (bibtex-actions-run-default-action keys)))
 
 (defun bibtex-actions--extract-keys (keys-entries)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -239,7 +239,9 @@ the following optional arguments:
 'REBUILD-CACHE' if t, forces rebuilding the cache before
 offering the selection candidates.
 
-It returns an alist of key-entry, where the entry is a field-value alist."
+It returns an alist of key-entry, where the entry is a
+field-value alist. Therefore, for each returned candidate, 'car'
+is the citekey, and 'cdr' is the alist of structured data."
   (let* ((crm-separator "\\s-*&\\s-*")
          (candidates (bibtex-actions--get-candidates rebuild-cache))
          (chosen
@@ -257,8 +259,8 @@ It returns an alist of key-entry, where the entry is a field-value alist."
      (lambda (choice)
        ;; Collect citation keys of selected candidate(s).
        (or (cdr (assoc choice candidates))
-           ;; Key is literal coming from embark, just pass it on
-           choice))
+           ;; REVIEW for embark at-point; how to explain?
+           (cdr (seq-find (lambda (cand) (equal choice (cadr cand))) candidates))))
      chosen)))
 
 (defun bibtex-actions-select-file (files)
@@ -367,10 +369,10 @@ key associated with each one."
     (maphash
      (lambda (citekey entry)
        (let* ((files
-               (when (or (bibtex-actions-get-value
-                          bibtex-actions-file-variable entry)
-                         (bibtex-actions-file--files-for-key
-                          entry bibtex-actions-library-paths bibtex-actions-file-extensions))
+               (when (bibtex-actions-file--files-for-key
+                      entry
+                      bibtex-actions-library-paths
+                      bibtex-actions-file-extensions)
                  " has:files"))
               (notes
                (when (bibtex-actions-file--files-for-key
@@ -624,7 +626,8 @@ With prefix, rebuild the cache before offering candidates."
   (let ((files
          (bibtex-actions-file--files-for-multiple-keys
           keys-entries
-          bibtex-actions-library-paths bibtex-actions-file-extensions)))
+          bibtex-actions-library-paths
+          bibtex-actions-file-extensions)))
     (if files
         (dolist (file files)
           (if bibtex-actions-open-library-file-external

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -508,6 +508,10 @@ If FORCE-REBUILD-CACHE is t, force reload the cache."
     (when field
       (concat base-url (bibtex-actions-get-value field entry)))))
 
+(defun bibtex-actions--extract-keys (keys-entries)
+  "Extract list of keys from KEYS-ENTRIES alist."
+  (seq-map #'car keys-entries))
+
 ;;;###autoload
 (defun bibtex-actions-insert-preset ()
   "Prompt for and insert a predefined search."
@@ -759,13 +763,6 @@ With prefix, rebuild the cache before offering candidates."
   (if-let ((keys (cdr (bibtex-actions-citation-key-at-point))))
       ;; FIX how?
       (bibtex-actions-run-default-action keys)))
-
-(defun bibtex-actions--extract-keys (keys-entries)
-  "Extract list of keys from KEYS-ENTRIES alist."
-  (seq-map
-   (lambda (key-entry)
-     (car key-entry))
-   keys-entries))
 
 (provide 'bibtex-actions)
 ;;; bibtex-actions.el ends here

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -258,9 +258,11 @@ offering the selection candidates."
            'bibtex-actions-history bibtex-actions-presets nil)))
     (seq-map
      (lambda (choice)
-       ;; Collect citation keys of selected candidate(s).
+       ;; Collect citation key-entry of selected candidate(s).
        (or (cdr (assoc choice candidates))
-           ;; REVIEW for embark at-point; how to explain?
+           ;; When calling embark at-point, use keys to look up and return the
+           ;; selected candidates.
+           ;; See https://github.com/bdarcus/bibtex-actions/issues/233#issuecomment-901536901
            (cdr (seq-find (lambda (cand) (equal choice (cadr cand))) candidates))))
      chosen)))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -372,17 +372,20 @@ key associated with each one."
     (maphash
      (lambda (citekey entry)
        (let* ((files
-               (when (bibtex-actions-file--files-for-key
+               (when (bibtex-actions-file--files-for-entry
                       entry
                       bibtex-actions-library-paths
                       bibtex-actions-file-extensions)
                  " has:files"))
               (notes
-               (when (bibtex-actions-file--files-for-key
-                      entry bibtex-actions-notes-paths bibtex-actions-file-extensions)
+               (when (bibtex-actions-file--files-for-entry
+                      entry
+                      bibtex-actions-notes-paths
+                      bibtex-actions-file-extensions)
                  " has:notes"))
-              (link (when (bibtex-actions-has-a-value '("doi" "url") entry)
-                      "has:link"))
+              (link
+               (when (bibtex-actions-has-a-value '("doi" "url") entry)
+                 "has:link"))
               (candidate-main
                (bibtex-actions--format-entry
                 entry
@@ -497,10 +500,9 @@ If FORCE-REBUILD-CACHE is t, force reload the cache."
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))
 
-(defun bibtex-actions-get-link (key)
-  "Return a link for a KEY."
-  (let* ((entry (cdr key))
-         (field (bibtex-actions-has-a-value '(doi pmid pmcid url) entry))
+(defun bibtex-actions-get-link (entry)
+  "Return a link for an ENTRY."
+  (let* ((field (bibtex-actions-has-a-value '(doi pmid pmcid url) entry))
          (base-url (pcase field
                      ('doi "https://doi.org/")
                      ('pmid "https://www.ncbi.nlm.nih.gov/pubmed/")
@@ -604,14 +606,14 @@ FORMAT-STRING."
   (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (let* ((files
-         (bibtex-actions-file--files-for-multiple-keys
-          (car keys-entries)
+         (bibtex-actions-file--files-for-multiple-entries
+          keys-entries
           (append bibtex-actions-library-paths bibtex-actions-notes-paths)
           bibtex-actions-file-extensions))
          (links
           (seq-map
-           (lambda (key)
-             (bibtex-actions-get-link (cdr key)))
+           (lambda (key-entry)
+             (bibtex-actions-get-link (cdr key-entry)))
            keys-entries))
         (resources
          (completing-read-multiple "Related resources: "
@@ -631,7 +633,7 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (let ((files
-         (bibtex-actions-file--files-for-multiple-keys
+         (bibtex-actions-file--files-for-multiple-entries
           keys-entries
           bibtex-actions-library-paths
           bibtex-actions-file-extensions)))

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -149,7 +149,8 @@ With PROC list, limits to specific processors."
 
 (defun oc-bibtex-actions-insert (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
-  (let ((references (bibtex-actions-select-keys)))
+  (let ((references (bibtex-actions--extract-keys
+                     (bibtex-actions-select-refs))))
     (if multiple
         references
       (car references))))


### PR DESCRIPTION
This is fundamentally to fix #286 (a recursion bug), but may have other benefits for modularity and performance.

1. change `bibtex-actions-select-keys` to `bibtex-actions-select-refs`, which now returns `(key . entry)`
2. change functions that rely on keys to accept this richer input instead
3. decouple action and formatting functions from caches (no more looking up data there, which caused the bug)

See:

https://github.com/bdarcus/bibtex-actions/pull/274#issuecomment-917413257

This seems to fix it @aikrahguzar, but I need to test more.

Also, maybe need to change the function names.