### PR TITLE
Adapt oc-bibtex-actions-insert to changed format

### DIFF
--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -149,7 +149,7 @@ With PROC list, limits to specific processors."
 
 (defun oc-bibtex-actions-insert (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
-  (let ((references (bibtex-actions-select-keys)))
+  (let ((references (mapcar #'car (bibtex-actions-select-refs))))
     (if multiple
         references
       (car references))))


### PR DESCRIPTION
Tried out the branch and it fetching data doesn't seem to get stuck anymore. But something like this was needed for `oc-bibtex-actions-insert` to work. Maybe this is not what is intended.