### PR TITLE
refactor: notes fn to take KEY and ENTRY args

### DIFF
--- a/README.org
+++ b/README.org
@@ -304,11 +304,13 @@ To add support for other major modes or citation syntax, you can write a functio
 ** Notes
 
 This package provides a =bibtex-actions-file-open-note-function= variable, and a simple default function.
-To substitute, for example, the org-roam-bibtex =orb-edit-note= function, you can do:
+To replace the default with one from org-roam-bibtex, you can do:
 
 #+BEGIN_SRC emacs-lisp
-(setq bibtex-actions-file-open-note-function 'orb-edit-note)
+(setq bibtex-actions-file-open-note-function 'orb-bibtex-actions-edit-note)
 #+END_SRC
+
+Note, however: if you use that function you need to ensure that the =bibtex-completion-bibliography= variable is correctly set to the same paths as =bibtex-actions-bibliographic=.
 
 ** Usage
    :PROPERTIES:
@@ -321,7 +323,7 @@ You have a few different ways to interact with these commands.
 
 Bibtex-actions includes org-cite integration in =oc-bibtex-actions=, which includes a processor with "follow" and "insert" capabilities.
 
-The "insert processor" will use =bibtex-actions-read= to browse your library to insert and edit citations and citation references using the =org-cite-insert= command.
+The "insert processor" will use =bibtex-actions-select-refs= to browse your library to insert and edit citations and citation references using the =org-cite-insert= command.
 
 The "follow processor" provides at-point functionality accessible via the =org-open-at-point= command.
 By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you invoke =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -48,8 +48,13 @@
   'bibtex-actions-file-open-notes-default-org
   "Function to open and existing or create a new note.
 
-If you use 'org-roam' and 'org-roam-bibtex', for example, you can
-use 'orb-edit-note' for this value."
+A note function must take two arguments:
+
+KEY: a string to represent the citekey
+ENTRY: an alist with the structured data (title, author, etc.)
+
+If you use 'org-roam' and 'org-roam-bibtex', you can use
+'orb-bibtex-actions-edit-note' for this value."
   :group 'bibtex-actions
   :type '(function))
 
@@ -170,18 +175,17 @@ use 'orb-edit-note' for this value."
                   nil 0 nil
                   file)))
 
-(defun bibtex-actions-file-open-notes-default-org (key-entry)
-  "Open a note file from KEY-ENTRY."
+(defun bibtex-actions-file-open-notes-default-org (key entry)
+  "Open a note file from KEY and ENTRY."
   ;; modify when this addressed:
   ;; https://github.com/org-roam/org-roam-bibtex/issues/211
   (if-let* ((file
              (caar (bibtex-actions-file--files-to-open-or-create
-                    (list key-entry)
+                    (list key)
                     bibtex-actions-notes-paths '("org"))))
             (file-exists (file-exists-p file)))
       (funcall bibtex-actions-file-open-function file)
     (let* ((uuid (org-id-new))
-           (entry (cdr key-entry))
            (note-meta
             (bibtex-actions--format-entry-no-widths
              entry

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -657,7 +657,8 @@ With prefix, rebuild the cache before offering candidates."
   (dolist (key-entry keys-entries)
     ;; REVIEW doing this means the function won't be compatible with, for
     ;; example, 'orb-edit-note'.
-    (funcall bibtex-actions-file-open-note-function key-entry)))
+    (funcall bibtex-actions-file-open-note-function
+             (car key-entry) (cdr key-entry))))
 
 ;;;###autoload
 (defun bibtex-actions-open-entry (keys-entries)


### PR DESCRIPTION
Better aligns with org-roam-bibtex.

See https://github.com/org-roam/org-roam-bibtex/pull/212