### PR TITLE
open file refinements

### DIFF
--- a/README.org
+++ b/README.org
@@ -305,6 +305,15 @@ If you have a mix of entries created with Zotero and Calibre, for example, you c
     bibtex-actions-file-parser-calibre))
 #+END_SRC
 
+These two variables govern what functions will open which extensions.
+
+#+BEGIN_SRC emacs-lisp
+(setq bibtex-actions-file-extensions '("org" "md" "pdf")
+      bibtex-actions-file-extensions-external '("mp3" "png" "tiff" "html"))
+#+END_SRC
+
+The first will open using =bibtex-actions-open=, which uses the function specified in =bibtex-actions-file-open-function= (the default here is =find-file=), while the second will use =bibtex-actions-file-open-external=.
+
 ** Usage
    :PROPERTIES:
    :CUSTOM_ID: usage

--- a/README.org
+++ b/README.org
@@ -305,14 +305,7 @@ If you have a mix of entries created with Zotero and Calibre, for example, you c
     bibtex-actions-file-parser-calibre))
 #+END_SRC
 
-These two variables govern what functions will open which extensions.
-
-#+BEGIN_SRC emacs-lisp
-(setq bibtex-actions-file-extensions '("org" "md" "pdf")
-      bibtex-actions-file-extensions-external '("mp3" "png" "tiff" "html"))
-#+END_SRC
-
-The first will open using =bibtex-actions-open=, which uses the function specified in =bibtex-actions-file-open-function= (the default here is =find-file=), while the second will use =bibtex-actions-file-open-external=.
+The =bibtex-actions-file-extension= variable governs which file extensions the open commands will recognize.
 
 ** Usage
    :PROPERTIES:

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -77,14 +77,6 @@ will open, via `bibtex-actions-file-open'."
   :group 'bibtex-actions
   :type '(repeat string))
 
-(defcustom bibtex-actions-file-extensions-external '("html")
-  "List of file extensions to open in an external application.
-
-These are the extensions 'bibtex-actions-file-open-external' will
-open."
-  :group 'bibtex-actions
-  :type '(repeat string))
-
 (defvar bibtex-actions-notes-paths)
 
 ;;;; Convenience functions for files and paths
@@ -144,12 +136,8 @@ open."
                   ;; Make sure this arg is non-nil.
                   (or dirs "")
                   file-field))
-               bibtex-actions-file-parser-functions)))
-           (results-file-filtered
-            (seq-filter
-             (lambda (file)
-               (member (file-name-extension file) extensions)) results-file)))
-      (append results-key results-file-filtered))))
+               bibtex-actions-file-parser-functions))))
+      (append results-key results-file))))
 
 (defun bibtex-actions-file--files-for-entry (key entry dirs extensions)
     "Find files related to KEY, ENTRY in DIRS with extension in EXTENSIONS."

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -152,7 +152,6 @@ open."
     (seq-filter #'file-exists-p
                 (bibtex-actions-file--possible-names key dirs extensions entry)))
 
-
 (defun bibtex-actions-file--files-for-multiple-entries (keys-entries dirs extensions)
   "Find files related to a list of KEYS-ENTRIES in DIRS with extension in EXTENSIONS."
   (seq-mapcat

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -144,8 +144,12 @@ open."
                   ;; Make sure this arg is non-nil.
                   (or dirs "")
                   file-field))
-               bibtex-actions-file-parser-functions))))
-      (append results-key results-file))))
+               bibtex-actions-file-parser-functions)))
+           (results-file-filtered
+            (seq-filter
+             (lambda (file)
+               (member (file-name-extension file) extensions)) results-file)))
+      (append results-key results-file-filtered))))
 
 (defun bibtex-actions-file--files-for-entry (key entry dirs extensions)
     "Find files related to KEY, ENTRY in DIRS with extension in EXTENSIONS."

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -64,8 +64,24 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
   :group 'bibtex-actions
   :type '(repeat function))
 
+(defcustom bibtex-actions-file-open-function 'find-file
+  "Function to use to open files."
+  :group 'bibtex-actions
+  :type '(function))
+
 (defcustom bibtex-actions-file-extensions '("pdf" "org" "md")
-  "A list of file extensions to recognize for related files."
+  "List of file extensions to recognize for related files.
+
+These are the extensions the 'bibtex-actions-file-open-function'
+will open, via `bibtex-actions-file-open'."
+  :group 'bibtex-actions
+  :type '(repeat string))
+
+(defcustom bibtex-actions-file-extensions-external '("html")
+  "List of file extensions to open in an external application.
+
+These are the extensions 'bibtex-actions-file-open-external' will
+open."
   :group 'bibtex-actions
   :type '(repeat string))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -489,6 +489,13 @@ If FORCE-REBUILD-CACHE is t, force reload the cache."
                    bibtex-actions--local-candidates-cache
                    bibtex-actions--candidates-cache))
 
+(defun bibtex-actions--get-entry (key)
+  "Return the cached entry for KEY."
+    (cddr (seq-find
+           (lambda (entry)
+             (string-equal key (cadr entry)))
+           (bibtex-actions--get-candidates))))
+
 (defun bibtex-actions-get-link (entry)
   "Return a link for an ENTRY."
   (let* ((field (bibtex-actions-has-a-value '(doi pmid pmcid url) entry))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -63,6 +63,7 @@
 (defvar embark-meta-map)
 (defvar bibtex-actions-file-open-note-function)
 (defvar bibtex-actions-file-extensions)
+(defvar bibtex-actions-file-extensions-external)
 (defvar bibtex-actions-file-open-prompt)
 (defvar bibtex-actions-file-variable)
 
@@ -98,20 +99,6 @@
   ;; The bibtex-completion default is likely to be removed in the future.
   :group 'bibtex-actions
   :type '(repeat path))
-
-
-(defcustom bibtex-actions-open-file-function 'find-file
-  "Function to use to open files."
-  ;; tODO maybe this should be higher-level; eg:
-  ;; 'bibtex-actions-open-file?
-  :group 'bibtex-actions
-  :type '(function))
-
-(defcustom bibtex-actions-open-library-file-external t
-  "Whether to open a library file in an external application."
-  :group 'bibtex-actions
-  :type '(boolean))
-
 
 (defcustom bibtex-actions-templates
   '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
@@ -624,7 +611,8 @@ FORMAT-STRING."
       (cond ((string-match "http" resource 0)
              (browse-url resource))
             ((equal (file-name-extension resource) (or "org" "md"))
-             (funcall bibtex-actions-open-file-function resource))
+             (bibtex-actions-file-open resource))
+            ;; FIX
             (t (bibtex-actions-file-open-external resource))))))
 
 ;;;###autoload
@@ -641,9 +629,10 @@ With prefix, rebuild the cache before offering candidates."
           bibtex-actions-file-extensions)))
     (if files
         (dolist (file files)
-          (if bibtex-actions-open-library-file-external
+          ;; FIX
+          (if bibtex-actions-file-extensions-external
               (bibtex-actions-file-open-external file)
-            (funcall bibtex-actions-file-open-function file)))
+            (bibtex-actions-file-open file)))
       (message "No file(s) found for %s"
                (bibtex-actions--extract-keys keys-entries)))))
 

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -363,14 +363,16 @@ key associated with each one."
                       citekey
                       entry
                       bibtex-actions-library-paths
-                      bibtex-actions-file-extensions)
+                      (append bibtex-actions-file-extensions
+                              bibtex-actions-file-extensions-external))
                  " has:files"))
               (notes
                (when (bibtex-actions-file--files-for-entry
                       citekey
                       entry
                       bibtex-actions-notes-paths
-                      bibtex-actions-file-extensions)
+                      (append bibtex-actions-file-extensions
+                              bibtex-actions-file-extensions-external))
                  " has:notes"))
               (link
                (when (bibtex-actions-has-a-value '("doi" "url") entry)
@@ -605,7 +607,7 @@ FORMAT-STRING."
          (bibtex-actions-file--files-for-multiple-entries
           keys-entries
           (append bibtex-actions-library-paths bibtex-actions-notes-paths)
-          bibtex-actions-file-extensions))
+          (append bibtex-actions-file-extensions bibtex-actions-file-extensions-external))
          (links
           (seq-map
            (lambda (key-entry)

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -363,16 +363,14 @@ key associated with each one."
                       citekey
                       entry
                       bibtex-actions-library-paths
-                      (append bibtex-actions-file-extensions
-                              bibtex-actions-file-extensions-external))
+                      bibtex-actions-file-extensions)
                  " has:files"))
               (notes
                (when (bibtex-actions-file--files-for-entry
                       citekey
                       entry
                       bibtex-actions-notes-paths
-                      (append bibtex-actions-file-extensions
-                              bibtex-actions-file-extensions-external))
+                      bibtex-actions-file-extensions)
                  " has:notes"))
               (link
                (when (bibtex-actions-has-a-value '("doi" "url") entry)
@@ -607,7 +605,7 @@ FORMAT-STRING."
          (bibtex-actions-file--files-for-multiple-entries
           keys-entries
           (append bibtex-actions-library-paths bibtex-actions-notes-paths)
-          (append bibtex-actions-file-extensions bibtex-actions-file-extensions-external))
+          (append bibtex-actions-file-extensions bibtex-actions-file-extensions-external)))
          (links
           (seq-map
            (lambda (key-entry)
@@ -615,14 +613,10 @@ FORMAT-STRING."
            keys-entries))
         (resources
          (completing-read-multiple "Related resources: "
-                                   (append files (remq nil links)))))
+                                   (delete-dups (append files (remq nil links))))))
     (dolist (resource resources)
       (cond ((string-match "http" resource 0)
              (browse-url resource))
-            ((member
-              (file-name-extension resource)
-              bibtex-actions-file-extensions-external)
-             (bibtex-actions-file-open-external resource))
             (t (bibtex-actions-file-open resource))))))
 
 ;;;###autoload
@@ -636,16 +630,9 @@ With prefix, rebuild the cache before offering candidates."
          (bibtex-actions-file--files-for-multiple-entries
           keys-entries
           bibtex-actions-library-paths
-          bibtex-actions-file-extensions))
-         (files-external
-          (bibtex-actions-file--files-for-multiple-entries
-           keys-entries
-           bibtex-actions-library-paths
-           bibtex-actions-file-extensions-external)))
+          bibtex-actions-file-extensions)))
     (dolist (file files)
-      (bibtex-actions-file-open file))
-    (dolist (file-external files-external)
-        (bibtex-actions-file-open-external file-external))))
+      (bibtex-actions-file-open file))))
 
 (make-obsolete 'bibtex-actions-open-pdf
                'bibtex-actions-open-library-files "1.0")

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -622,19 +622,20 @@ FORMAT-STRING."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
-  (let ((files
+  (let* ((files
          (bibtex-actions-file--files-for-multiple-entries
           keys-entries
           bibtex-actions-library-paths
-          bibtex-actions-file-extensions)))
-    (if files
-        (dolist (file files)
-          ;; FIX
-          (if bibtex-actions-file-extensions-external
-              (bibtex-actions-file-open-external file)
-            (bibtex-actions-file-open file)))
-      (message "No file(s) found for %s"
-               (bibtex-actions--extract-keys keys-entries)))))
+          bibtex-actions-file-extensions))
+         (files-external
+          (bibtex-actions-file--files-for-multiple-entries
+           keys-entries
+           bibtex-actions-library-paths
+           bibtex-actions-file-extensions-external)))
+    (dolist (file files)
+      (bibtex-actions-file-open file))
+    (dolist (file-external files-external)
+        (bibtex-actions-file-open-external file-external))))
 
 (make-obsolete 'bibtex-actions-open-pdf
                'bibtex-actions-open-library-files "1.0")

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -680,13 +680,7 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (bibtex-actions-select-refs
                       :rebuild-cache current-prefix-arg)))
   (dolist (key-entry keys-entries)
-    (let* ((doi
-            (bibtex-actions-get-value "doi" (cdr key-entry)))
-           (doi-url
-            (when doi
-              (concat "https://doi.org/" doi)))
-           (url (bibtex-actions-get-value "url" (cdr key-entry)))
-           (link (or doi-url url)))
+    (let ((link (bibtex-actions-get-link (cdr key-entry))))
       (if link
           (browse-url-default-browser link)
         (message "No link found for %s" key-entry)))))

--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -610,10 +610,11 @@ FORMAT-STRING."
     (dolist (resource resources)
       (cond ((string-match "http" resource 0)
              (browse-url resource))
-            ((equal (file-name-extension resource) (or "org" "md"))
-             (bibtex-actions-file-open resource))
-            ;; FIX
-            (t (bibtex-actions-file-open-external resource))))))
+            ((member
+              (file-name-extension resource)
+              bibtex-actions-file-extensions-external)
+             (bibtex-actions-file-open-external resource))
+            (t (bibtex-actions-file-open resource))))))
 
 ;;;###autoload
 (defun bibtex-actions-open-library-files (keys-entries)


### PR DESCRIPTION
Fix #282, #273; see also #226 and #229

cc @pRot0ta1p @salutis

I've implemented changes here to `bibtex-actions-open-library-files` and `bibtex-actions-open` interactive functions, and related defcustoms.

So to configure flie handling, you can do this:

```elisp
(setq bibtex-actions-file-extensions '("org" "md" "pdf") ; open with the default open command; find-file
      bibtex-actions-file-extensions-external '("mp3" "png" "tiff" "html"))
```

WDYT? 

TODO:

1. need to make sure this works correctly with file-fields

Aside: occurs to me HTML may be a little tricky, because we pretty much only want to view these files; not edit them. But some may want to view in emacs.