### PR TITLE
refactor file parsers and broaden syntax support

### DIFF
--- a/README.org
+++ b/README.org
@@ -296,13 +296,17 @@ Note, however: if you use that function you need to ensure that the =bibtex-comp
 
 If you have =bibtex-actions-library-paths= set, the relevant open commands will look in those directories for file names of =CITEKEY.EXTENSION=.
 They will also parse contents of a file-field.
-The =bibtex-actions-file-parser-functions= variable governs which parsers to use.
-If you have a mix of entries created with Zotero and Calibre, for example, you can set it like so and it will parse both:
+The =bibtex-actions-file-parser-functions= variable governs which parsers to use, and there are two included parsers:
+
+1. The default =bibtex-actions-file-parser-default= parser works for simple semi-colon-delimited lists of file paths, as in Zotero.
+2. The =bibtex-actions-file-parser-triplet= works for Mendeley and Calibre, which represent files using a format like =:/path/file.pdf:PDF=.
+
+If you have a mix of entries created with Zotero and Calibre, you can set it like so and it will parse both:
 
 #+BEGIN_SRC emacs-lisp
 (setq bibtex-actions-file-parser-functions
-  '(bibtex-actions-file-parser-zotero
-    bibtex-actions-file-parser-calibre))
+  '(bibtex-actions-file-parser-default
+    bibtex-actions-file-parser-triplet))
 #+END_SRC
 
 The =bibtex-actions-file-extension= variable governs which file extensions the open commands will recognize.

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -100,8 +100,10 @@ will open, via `bibtex-actions-file-open'."
           (expand-file-name file dir)) files))
      dirs)))
 
-(defun bibtex-actions-file-parser-calibre (dirs file-field)
-  "Return a list of files from DIRS and a Calibre formatted FILE-FIELD."
+(defun bibtex-actions-file-parser-triplet (dirs file-field)
+  "Return a list of files from DIRS and a FILE-FIELD formatted as a triplet.
+
+Example: ':/path/to/test.pdf:PDF'."
   (let ((parts (split-string file-field "[,;]" 'omit-nulls)))
     (seq-mapcat
      (lambda (part)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -91,11 +91,7 @@ will open, via `bibtex-actions-file-open'."
       (lambda (p) (file-truename p)) file-paths))))
 
 (defun bibtex-actions-file-parser-default (dirs file-field)
-  "Return a list of files from base directories DIRS and FILE-FIELD."
-  (seq-map (lambda (dir) (expand-file-name file-field dir)) dirs))
-
-(defun bibtex-actions-file-parser-zotero (dirs file-field)
-  "Return a list of files from DIRS and a Zotero formatted FILE-FIELD."
+  "Return a list of files from DIRS and FILE-FIELD."
   (let ((files (split-string file-field ";")))
     (seq-mapcat
      (lambda (dir)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -107,9 +107,10 @@ Example: ':/path/to/test.pdf:PDF'."
   (let ((parts (split-string file-field "[,;]" 'omit-nulls)))
     (seq-mapcat
      (lambda (part)
-       (when (string-match ":\\(.*\\):.*" part)
-	 (let ((fn (replace-regexp-in-string "\\\\:" ":" (match-string 1 part))))
-           (mapcar (apply-partially #'expand-file-name fn) dirs))))
+	   (let ((fn (if (string-match ":\\(.*\\):.*" part)
+					 (replace-regexp-in-string "\\\\:" ":" (match-string 1 part))
+				   part)))
+		 (mapcar (apply-partially #'expand-file-name fn) dirs)))
      parts)))
 
 (defun bibtex-actions-file--possible-names (key dirs extensions &optional entry)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -132,7 +132,7 @@ Example: ':/path/to/test.pdf:PDF'."
                  (funcall
                   func
                   ;; Make sure this arg is non-nil.
-                  (or dirs "")
+                  (or dirs "/")
                   file-field))
                bibtex-actions-file-parser-functions))))
       (append results-key results-file))))

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -107,8 +107,9 @@ Example: ':/path/to/test.pdf:PDF'."
   (let ((parts (split-string file-field "[,;]" 'omit-nulls)))
     (seq-mapcat
      (lambda (part)
-       (let ((fn (car (split-string part ":" t))))
-         (mapcar (apply-partially #'expand-file-name fn) dirs)))
+       (when (string-match ":\\(.*\\):.*" part)
+	 (let ((fn (replace-regexp-in-string "\\\\:" ":" (match-string 1 part))))
+           (mapcar (apply-partially #'expand-file-name fn) dirs))))
      parts)))
 
 (defun bibtex-actions-file--possible-names (key dirs extensions &optional entry)

--- a/bibtex-actions-file.el
+++ b/bibtex-actions-file.el
@@ -106,7 +106,7 @@ will open, via `bibtex-actions-file-open'."
 
 (defun bibtex-actions-file-parser-calibre (dirs file-field)
   "Return a list of files from DIRS and a Calibre formatted FILE-FIELD."
-  (let ((parts (split-string file-field ", *" 'omit-nulls)))
+  (let ((parts (split-string file-field "[,;]" 'omit-nulls)))
     (seq-mapcat
      (lambda (part)
        (let ((fn (car (split-string part ":" t))))


### PR DESCRIPTION
1. rename the zotero parser to default
2. add a semi-colon option to the calibre parser, rename it

Is this OK @thisirs?

@pRot0ta1p - isn't this the only change needed?

Assuming yes, what's a better name for the "calibre" parser, since it's now broader? Here's I've renamed it to "triplet".

Also, do you know if semi-colon is consistently used as the delimiter for this simpler syntax? 

Fix #296