### PR TITLE
add org-cite citation editing commands

### DIFF
--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -223,6 +223,27 @@ strings by style."
   (when-let ((keys (bibtex-actions-get-key-org-cite)))
     (cons 'oc-citation (bibtex-actions--stringify-keys keys))))
 
+;;; Functions for editing/modifying citations
+
+(defun oc-bibtex-actions-delete-citation ()
+  "Delete the citation-reference or citation at point."
+  (interactive)
+  (org-cite-delete-citation (org-element-context)))
+
+(defun oc-bibtex-actions--shift-reference (direction)
+  "When point is on a citation-reference, shift it in DIRECTION."
+  (when direction "TODO"))
+
+(defun oc-bibtex-actions-shift-reference-left ()
+  "When point is on a citation-reference, shift it left."
+  (interactive)
+  (oc-bibtex-actions--shift-reference 'left))
+
+(defun oc-bibtex-actions-shift-reference-right ()
+  "When point is on a citation-reference, shift it right."
+  (interactive)
+  (oc-bibtex-actions--shift-reference 'right))
+
 ;;; Keymap
 
 (defvar oc-bibtex-actions-map
@@ -233,6 +254,18 @@ strings by style."
     (define-key map (kbd "l") '("open source link" . bibtex-actions-open-link))
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
+    map)
+  "Keymap for 'oc-bibtex-actions' `embark' minibuffer functionality.")
+
+(defvar oc-bibtex-actions-buffer-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "o") '("open source (file or link)" . bibtex-actions-open))
+    (define-key map (kbd "e") '("open bibtex entry" . bibtex-actions-open-entry))
+    (define-key map (kbd "f") '("open source file" . bibtex-actions-open-library-files))
+    (define-key map (kbd "l") '("open source link" . bibtex-actions-open-link))
+    (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
+    (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
+    (define-key map (kbd "d") '("delete citation" . oc-bibtex-actions-delete-citation))
     map)
   "Keymap for 'oc-bibtex-actions' `embark' at-point functionality.")
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -231,9 +231,15 @@ strings by style."
 ;; most of this section is adapted from org-ref-cite
 
 (defun oc-bibtex-actions-delete-citation ()
-  "Delete the citation-reference or citation at point."
+  "Delete the citation or citation-reference at point."
   (interactive)
   (org-cite-delete-citation (org-element-context)))
+
+(defun oc-bibtex-actions-kill-citation ()
+  "Kill (copy) the citation or citation-reference at point."
+  (interactive)
+  (let* ((datum (org-element-context)))
+    (kill-region (org-element-property :begin datum) (org-element-property :end datum))))
 
 (defun oc-bibtex-actions-cite-swap (i j lst)
   "Swap index I and J in the list LST."
@@ -308,6 +314,7 @@ strings by style."
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
     (define-key map (kbd "d") '("delete citation" . oc-bibtex-actions-delete-citation))
+    (define-key map (kbd "k") '("kill/copy citation" . oc-bibtex-actions-kill-citation))
     map)
   "Keymap for 'oc-bibtex-actions' `embark' at-point functionality.")
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -230,6 +230,13 @@ strings by style."
 
 ;; most of this section is adapted from org-ref-cite
 
+(defun oc-bibtex-actions--get-ref-index (refs ref)
+  "Return index of citation-reference REF within REFS."
+  (seq-position refs ref
+                (lambda (r1 r2)
+                  (and (string= (org-element-property :key r1)
+                                (org-element-property :key r2))))))
+
 (defun oc-bibtex-actions-delete-citation ()
   "Delete the citation or citation-reference at point."
   (interactive)
@@ -255,10 +262,7 @@ strings by style."
           (current-ref (when (eq 'citation-reference (org-element-type datum)) datum))
           (refs (org-cite-get-references current-citation))
           (index
-           (seq-position refs current-ref
-                         (lambda (r1 r2)
-                           (string= (org-element-property :key r1)
-                                    (org-element-property :key r2))))))
+           (oc-bibtex-actions--get-ref-index refs current-ref)))
 
     (when (= 1 (length refs))
       (error "You only have one reference; you cannot shift this"))
@@ -273,10 +277,7 @@ strings by style."
     ;; Now get on the original ref.
     (let* ((newrefs (org-cite-get-references current-citation))
            (index
-            (seq-position newrefs current-ref
-                          (lambda (r1 r2)
-                            (string= (org-element-property :key r1)
-                                     (org-element-property :key r2))))))
+            (oc-bibtex-actions--get-ref-index newrefs current-ref)))
 
       (goto-char (org-element-property :begin (nth index newrefs))))))
 
@@ -314,7 +315,9 @@ strings by style."
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
     (define-key map (kbd "d") '("delete citation" . oc-bibtex-actions-delete-citation))
-    (define-key map (kbd "k") '("kill/copy citation" . oc-bibtex-actions-kill-citation))
+    (define-key map (kbd "k") '("kill citation" . oc-bibtex-actions-kill-citation))
+    (define-key map (kbd "S-<left>") '("shift left" . oc-bibtex-actions-shift-reference-left))
+    (define-key map (kbd "S-<right>") '("shift right" . oc-bibtex-actions-shift-reference-right))
     map)
   "Keymap for 'oc-bibtex-actions' `embark' at-point functionality.")
 
@@ -322,7 +325,7 @@ strings by style."
 
 (add-to-list 'embark-target-finders 'oc-bibtex-actions-citation-finder)
 (add-to-list 'embark-keymap-alist '(bib-reference . oc-bibtex-actions-map))
-(add-to-list 'embark-keymap-alist '(oc-citation . oc-bibtex-actions-map))
+(add-to-list 'embark-keymap-alist '(oc-citation . oc-bibtex-actions-buffer-map))
 (when (boundp 'embark-pre-action-hooks)
   ;; Ensure that Embark ignores the target for 'org-cite-insert'.
   (add-to-list 'embark-pre-action-hooks '(org-cite-insert embark--ignore-target)))


### PR DESCRIPTION
This adapts some of the functions from org-ref-cite (whose future is now unclear) for modifying citations.

The delete-citation and kill are simple no-brainers.

The "shift" ones seem useful to me, and would ideally work the same as in org-ref-cite; they'd be attached via keymap face, so one could use arrow keys. 

Not sure what else, given we already cover the key ones.

I could add the pre/post (affix) one, but not sure how useful that is, given how can just directly add the content in the buffer.

See #302; cc @andras-simonyi (both because related to previous discussion of activate processors, and because you might have input on my note below)