### PR TITLE
run bibtex-actions-refresh when inserting

### DIFF
--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -152,6 +152,7 @@ With PROC list, limits to specific processors."
 
 (defun oc-bibtex-actions-insert (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
+  (bibtex-actions-refresh)
   (let ((references (bibtex-actions--extract-keys
                      (bibtex-actions-select-refs))))
     (if multiple


### PR DESCRIPTION
Runs bibtex-actions-refresh when running oc-bibtex-actions-insert as my workflows has a constantly changing bib file being managed by Zotero.

An overly simple solution to having periodically run bibtex-actions-refresh manually.