### PR TITLE
feat(oc): add mouse keybindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -343,6 +343,10 @@ That keymap includes the following bindings that provide additional citation and
 | C-k       | oc-bibtex-actions-kill-citation         |
 | S-<left>  | oc-bibtex-actions-shift-reference-left  |
 | S-<right> | oc-bibtex-actions-shift-reference-right |
+| C-p       | oc-bibtex-actions-update-pre-suffix     |
+| <mouse-1> | bibtex-actions-dwim                     |
+| <mouse-3> | embark-act                              |
+
 
 The "follow processor" provides at-point functionality accessible via the =org-open-at-point= command.
 By default, in org-mode with org-cite support, when point is on a citation or citation-reference, and you invoke =org-open-at-point=, it will run the default command, which is =bibtex-actions-open=.

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -200,13 +200,15 @@ strings by style."
 
 (defvar oc-bibtex-actions-citation-keymap
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "<mouse-1>") '("default action" . bibtex-actions-dwim))
+    (define-key map (kbd "<mouse-3>") '("embark act" . embark-act))
     (define-key map (kbd "C-d") '("delete citation" . oc-bibtex-actions-delete-citation))
     (define-key map (kbd "C-k") '("kill citation" . oc-bibtex-actions-kill-citation))
     (define-key map (kbd "S-<left>") '("shift left" . oc-bibtex-actions-shift-reference-left))
     (define-key map (kbd "S-<right>") '("shift right" . oc-bibtex-actions-shift-reference-right))
     (define-key map (kbd "C-p") '("update prefix/suffix" . oc-bibtex-actions-update-pre-suffix))
     map)
-  "A keymap for editing org citations.")
+  "A keymap for interacting with org citations.")
 
 (defun oc-bibtex-actions-describe-keymap ()
   "Describe the `oc-bibtex-actions-citation-keymap' keymap."


### PR DESCRIPTION
This allows left-click for bibtex-actions-dwim and right-click for embark-act.