### PR TITLE
refactor: move/generalize describe-keymap function

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -180,7 +180,7 @@ and nil means no action."
 
 ;;; Keymaps
 
-(defvar bibtex-actions-map
+(defcustom bibtex-actions-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "t") '("add pdf attachment" . bibtex-actions-add-pdf-attachment))
     (define-key map (kbd "a") '("add pdf to library" . bibtex-actions-add-pdf-to-library))
@@ -198,9 +198,11 @@ and nil means no action."
     ;; https://github.com/oantolin/embark/issues/251
     (define-key map (kbd "RET") '("default action" . bibtex-actions-run-default-action))
     map)
-  "Keymap for 'bibtex-actions'.")
+  "Keymap for Embark minibuffer actions."
+  :group 'oc-bibtex-actions
+  :type '(restricted-sexp :match-alternatives (keymapp)))
 
-(defvar bibtex-actions-buffer-map
+(defcustom bibtex-actions-buffer-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "o") '("open source document" . bibtex-actions-open))
     (define-key map (kbd "e") '("open bibtex entry" . bibtex-actions-open-entry))
@@ -212,7 +214,22 @@ and nil means no action."
     ;; https://github.com/oantolin/embark/issues/251
     (define-key map (kbd "RET") '("default action" . bibtex-actions-run-default-action))
     map)
-  "Keymap for Embark citation-key actions.")
+  "Keymap for Embark citation-key actions."
+  :group 'bibtex-actions
+  :type '(restricted-sexp :match-alternatives (keymapp)))
+
+;;; Describe keymaps
+
+(defvar bibtex-actions-keymaps
+  (list
+   'bibtex-actions-map
+   'bibtex-actions-buffer-map))
+
+(defun bibtex-actions-describe-keymap ()
+  "Describe the selected keymap."
+  (interactive)
+  (let ((km (completing-read "Keymap: " (sort bibtex-actions-keymaps #'string<))))
+    (describe-keymap km)))
 
 ;;; Completion functions
 

--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -87,7 +87,7 @@ Each function takes one argument, a citation."
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
     map)
-  "Keymap for 'oc-bibtex-actions' `embark' minibuffer functionality."
+  "Keymap for org-cite Embark minibuffer functionality."
   :group 'oc-bibtex-actions
   :type '(restricted-sexp :match-alternatives (keymapp)))
 
@@ -100,11 +100,11 @@ Each function takes one argument, a citation."
     (define-key map (kbd "n") '("open notes" . bibtex-actions-open-notes))
     (define-key map (kbd "r") '("refresh" . bibtex-actions-refresh))
     map)
-  "Keymap for 'oc-bibtex-actions' `embark' at-point functionality."
+  "Keymap for org-cite Embark at-point functionality."
   :group 'oc-bibtex-actions
   :type '(restricted-sexp :match-alternatives (keymapp)))
 
-(defcustom oc-bibtex-actions-citation-keymap
+(defcustom oc-bibtex-actions-citation-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<mouse-1>") '("default action" . bibtex-actions-dwim))
     (define-key map (kbd "<mouse-3>") '("embark act" . embark-act))
@@ -114,9 +114,15 @@ Each function takes one argument, a citation."
     (define-key map (kbd "S-<right>") '("shift right" . oc-bibtex-actions-shift-reference-right))
     (define-key map (kbd "C-p") '("update prefix/suffix" . oc-bibtex-actions-update-pre-suffix))
     map)
-  "A keymap for interacting with org citations."
+  "Keymap for interacting with org citations at point."
   :group 'oc-bibtex-actions
   :type '(restricted-sexp :match-alternatives (keymapp)))
+
+;; Add keymaps to list.
+(defvar bibtex-actions-keymaps)
+
+(dolist (km '(oc-bibtex-actions-map oc-bibtex-actions-citation-map))
+  (push km bibtex-actions-keymaps))
 
 ;; TODO maybe connvert to defcustoms. But this is not really the right approach;
 ;; better to just run the export processors to get the previews. But we need
@@ -240,16 +246,11 @@ strings by style."
 
 ;; most of this section is adapted from org-ref-cite
 
-(defun oc-bibtex-actions-describe-keymap ()
-  "Describe the `oc-bibtex-actions-citation-keymap' keymap."
-  (interactive)
-  (describe-keymap oc-bibtex-actions-citation-keymap))
-
 (defun oc-bibtex-actions-activate-keymap (citation)
   "Activation function for CITATION to add keymap and tooltip."
   (pcase-let ((`(,beg . ,end) (org-cite-boundaries citation)))
     ;; Put the keymap on a citation
-    (put-text-property beg end 'keymap oc-bibtex-actions-citation-keymap)))
+    (put-text-property beg end 'keymap oc-bibtex-actions-citation-map)))
 
 (defun oc-bibtex-actions--get-ref-index (refs ref)
   "Return index of citation-reference REF within REFS."


### PR DESCRIPTION
Move the function to bibtex-actions.el, and use it to describe all
bibtex-actions keymaps.